### PR TITLE
Move Proxy storage into its own contract

### DIFF
--- a/contracts/Proxy.sol
+++ b/contracts/Proxy.sol
@@ -1,9 +1,11 @@
 pragma solidity 0.4.19;
 
-
-contract Proxy {
+contract ProxyStorage {
 
     address masterCopy;
+}
+
+contract Proxy is ProxyStorage {
 
     function Proxy(address _masterCopy)
         public


### PR DESCRIPTION
Similar to other proxy designs / setups it's often good to move the storage of a delegatecall system into it's own inheritable contract.

That way when I'm building another system that will be proxied I can just inherit the top level storage pointers from "ProxyStorage". No need for a new document though =D