### PR TITLE
Feature: Make example `OnlyOwnersGuard` universal

### DIFF
--- a/contracts/examples/guards/OnlyOwnersGuard.sol
+++ b/contracts/examples/guards/OnlyOwnersGuard.sol
@@ -12,9 +12,7 @@ interface ISafe {
 contract OnlyOwnersGuard is BaseGuard {
     ISafe public safe;
 
-    constructor(address _safe) public {
-        safe = ISafe(_safe);
-    }
+    constructor() {}
 
     function checkTransaction(
         address,
@@ -31,7 +29,7 @@ contract OnlyOwnersGuard is BaseGuard {
         address msgSender
     ) external override {
         // Only owners can exec
-        address[] memory owners = safe.getOwners();
+        address[] memory owners = ISafe(msg.sender).getOwners();
         for (uint256 i = 0; i < owners.length; i++) {
             if (owners[i] == msgSender) {
                 return;

--- a/test/guards/OnlyOwnersGuard.spec.ts
+++ b/test/guards/OnlyOwnersGuard.spec.ts
@@ -2,8 +2,7 @@ import { expect } from "chai";
 import hre, { deployments, waffle } from "hardhat";
 import "@nomiclabs/hardhat-ethers";
 import { getMock, getSafeWithOwners } from "../utils/setup";
-import { buildSafeTransaction, calculateSafeTransactionHash, executeContractCallWithSigners, executeTxWithSigners } from "../../src/utils/execution";
-import { chainId } from "../utils/encoding";
+import { buildSafeTransaction, executeContractCallWithSigners, executeTxWithSigners } from "../../src/utils/execution";
 
 describe("OnlyOwnersGuard", async () => {
 
@@ -13,7 +12,7 @@ describe("OnlyOwnersGuard", async () => {
         await deployments.fixture();
         const safe = await getSafeWithOwners([user1.address])
         const guardFactory = await hre.ethers.getContractFactory("OnlyOwnersGuard");
-        const guard = await guardFactory.deploy(safe.address)
+        const guard = await guardFactory.deploy()
         const mock = await getMock()
         await executeContractCallWithSigners(safe, safe, "setGuard", [guard.address], [user1])
 
@@ -28,7 +27,7 @@ describe("OnlyOwnersGuard", async () => {
             const { safe, mock } = await setupTests()
             const nonce = await safe.nonce()
             const safeTx = buildSafeTransaction({ to: mock.address, data: "0xbaddad42", nonce })
-            const safeTxHash = calculateSafeTransactionHash(safe, safeTx, await chainId())
+
             executeTxWithSigners(safe, safeTx, [user1])
         })
 
@@ -36,7 +35,7 @@ describe("OnlyOwnersGuard", async () => {
             const { safe, mock } = await setupTests()
             const nonce = await safe.nonce()
             const safeTx = buildSafeTransaction({ to: mock.address, data: "0xbaddad42", nonce })
-            const safeTxHash = calculateSafeTransactionHash(safe, safeTx, await chainId())
+
             await expect(
                 executeTxWithSigners(safe, safeTx, [user2])
             ).to.be.reverted


### PR DESCRIPTION
Per @rmeissner suggestion the guard can be made universal by using `msg.sender` inside the method instead of constructor-set address variable