### PR TITLE
1.4.0: Add test for `0xffffffff` interface EIP-165

### DIFF
--- a/test/handlers/DefaultCallbackHandler.spec.ts
+++ b/test/handlers/DefaultCallbackHandler.spec.ts
@@ -69,5 +69,12 @@ describe("DefaultCallbackHandler", async () => {
                 await handler.callStatic.supportsInterface("0xbaddad42")
             ).to.be.eq(false)
         })
+
+        it('should not support invalid interface', async () => {
+            const handler = await getDefaultCallbackHandler()
+            await expect(
+                await handler.callStatic.supportsInterface("0xffffffff")
+            ).to.be.eq(false)
+        })
     })
 })


### PR DESCRIPTION
This PR:
- implements https://github.com/safe-global/safe-contracts/issues/453

I didn't implement non-supported interface from the issue because it's already there.