### PR TITLE
Fix: Make singleton the first inherited PR

### DIFF
--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -17,8 +17,8 @@ import "./external/SafeMath.sol";
 /// @author Stefan George - <stefan@gnosis.io>
 /// @author Richard Meissner - <richard@gnosis.io>
 contract Safe is
-    EtherPaymentFallback,
     Singleton,
+    EtherPaymentFallback,
     ModuleManager,
     OwnerManager,
     SignatureDecoder,


### PR DESCRIPTION
Doesn't affect functionality but the docs for the Singleton contract say it should always be the first super contract:
https://github.com/safe-global/safe-contracts/blob/main/contracts/common/Singleton.sol#L4