### PR TITLE
Refactor: Rename EtherPaymentFallback to NativeCurrencyPaymentFallback

### DIFF
--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -5,7 +5,7 @@ import "./base/ModuleManager.sol";
 import "./base/OwnerManager.sol";
 import "./base/FallbackManager.sol";
 import "./base/GuardManager.sol";
-import "./common/EtherPaymentFallback.sol";
+import "./common/NativeCurrencyPaymentFallback.sol";
 import "./common/Singleton.sol";
 import "./common/SignatureDecoder.sol";
 import "./common/SecuredTokenTransfer.sol";
@@ -18,7 +18,7 @@ import "./external/SafeMath.sol";
 /// @author Richard Meissner - <richard@gnosis.io>
 contract Safe is
     Singleton,
-    EtherPaymentFallback,
+    NativeCurrencyPaymentFallback,
     ModuleManager,
     OwnerManager,
     SignatureDecoder,

--- a/contracts/common/NativeCurrencyPaymentFallback.sol
+++ b/contracts/common/NativeCurrencyPaymentFallback.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
  * @title EtherPaymentFallback - A contract that has a fallback to accept native currency payments.
  * @author Richard Meissner - @rmeissner
  */
-contract EtherPaymentFallback {
+contract NativeCurrencyPaymentFallback {
     event SafeReceived(address indexed sender, uint256 value);
 
     /**


### PR DESCRIPTION
Addressing the feedback from https://github.com/safe-global/safe-contracts/pull/510