### PR TITLE
Rename `DefaultCallbackHandler` to `TokenFallbackHandler`

### DIFF
--- a/benchmark/utils/setup.ts
+++ b/benchmark/utils/setup.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import hre, { deployments, waffle } from "hardhat";
 import "@nomiclabs/hardhat-ethers";
-import { getDefaultCallbackHandler, getSafeWithOwners } from "../../test/utils/setup";
+import { getTokenCallbackHandler, getSafeWithOwners } from "../../test/utils/setup";
 import { logGas, executeTx, SafeTransaction, safeSignTypedData, SafeSignature, executeContractCallWithSigners } from "../../src/utils/execution";
 import { Wallet, Contract } from "ethers";
 import { AddressZero } from "@ethersproject/constants";
@@ -14,7 +14,7 @@ export interface Contracts {
 }
 
 const generateTarget = async (owners: Wallet[], threshold: number, guardAddress: string, logGasUsage?: boolean) => {
-    const fallbackHandler = await getDefaultCallbackHandler()
+    const fallbackHandler = await getTokenCallbackHandler()
     const safe = await getSafeWithOwners(owners.map((owner) => owner.address), threshold, fallbackHandler.address, logGasUsage)
     await executeContractCallWithSigners(safe, safe, "setGuard", [guardAddress], owners)
     return safe

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import "./DefaultCallbackHandler.sol";
+import "./TokenCallbackHandler.sol";
 import "../interfaces/ISignatureValidator.sol";
 import "../Safe.sol";
 
@@ -9,7 +9,7 @@ import "../Safe.sol";
  * @title Compatibility Fallback Handler - Provides compatibility between pre 1.3.0 and 1.3.0+ Safe contracts.
  * @author Richard Meissner - @rmeissner
  */
-contract CompatibilityFallbackHandler is DefaultCallbackHandler, ISignatureValidator {
+contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidator {
     // keccak256("SafeMessage(bytes message)");
     bytes32 private constant SAFE_MSG_TYPEHASH = 0x60b3cbf8b4a223d68d641b3b6ddf9a298e7f33710cf3d3a9d1146b5a6150fbca;
 

--- a/contracts/handler/TokenCallbackHandler.sol
+++ b/contracts/handler/TokenCallbackHandler.sol
@@ -10,7 +10,7 @@ import "../interfaces/IERC165.sol";
  * @title Default Callback Handler - Handles supported tokens' callbacks, allowing Safes receiving these tokens.
  * @author Richard Meissner - @rmeissner
  */
-contract DefaultCallbackHandler is ERC1155TokenReceiver, ERC777TokensRecipient, ERC721TokenReceiver, IERC165 {
+contract TokenCallbackHandler is ERC1155TokenReceiver, ERC777TokensRecipient, ERC721TokenReceiver, IERC165 {
     string public constant NAME = "Default Callback Handler";
     string public constant VERSION = "1.0.0";
 

--- a/src/deploy/deploy_handlers.ts
+++ b/src/deploy/deploy_handlers.ts
@@ -6,7 +6,7 @@ const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     const { deployer } = await getNamedAccounts();
     const { deploy } = deployments;
 
-    await deploy("DefaultCallbackHandler", {
+    await deploy("TokenCallbackHandler", {
         from: deployer,
         args: [],
         log: true,

--- a/test/core/Safe.FallbackManager.spec.ts
+++ b/test/core/Safe.FallbackManager.spec.ts
@@ -3,7 +3,12 @@ import hre, { deployments, waffle } from "hardhat";
 import { BigNumber } from "ethers";
 import "@nomiclabs/hardhat-ethers";
 import { AddressZero } from "@ethersproject/constants";
-import { defaultCallbackHandlerContract, defaultCallbackHandlerDeployment, deployContract, getMock, getSafeTemplate } from "../utils/setup";
+import {
+    defaultTokenCallbackHandlerContract,
+    defaultTokenCallbackHandlerDeployment,
+    deployContract,
+    getSafeTemplate,
+} from "../utils/setup";
 import { executeContractCallWithSigners } from "../../src/utils/execution";
 
 describe("FallbackManager", async () => {
@@ -31,7 +36,7 @@ describe("FallbackManager", async () => {
     describe("setFallbackManager", async () => {
         it("is correctly set on deployment", async () => {
             const { safe } = await setupWithTemplate();
-            const handler = await defaultCallbackHandlerDeployment();
+            const handler = await defaultTokenCallbackHandlerDeployment();
 
             // Check fallback handler
             await expect(
@@ -49,7 +54,7 @@ describe("FallbackManager", async () => {
 
         it("is correctly set", async () => {
             const { safe } = await setupWithTemplate();
-            const handler = await defaultCallbackHandlerDeployment();
+            const handler = await defaultTokenCallbackHandlerDeployment();
 
             // Setup Safe
             await safe.setup([user1.address, user2.address], 1, AddressZero, "0x", AddressZero, AddressZero, 0, AddressZero);
@@ -71,7 +76,7 @@ describe("FallbackManager", async () => {
 
         it("emits event when is set", async () => {
             const { safe } = await setupWithTemplate();
-            const handler = await defaultCallbackHandlerDeployment();
+            const handler = await defaultTokenCallbackHandlerDeployment();
 
             // Setup Safe
             await safe.setup([user1.address, user2.address], 1, AddressZero, "0x", AddressZero, AddressZero, 0, AddressZero);
@@ -84,8 +89,8 @@ describe("FallbackManager", async () => {
 
         it("is called when set", async () => {
             const { safe } = await setupWithTemplate();
-            const handler = await defaultCallbackHandlerDeployment();
-            const safeHandler = (await defaultCallbackHandlerContract()).attach(safe.address);
+            const handler = await defaultTokenCallbackHandlerDeployment();
+            const safeHandler = (await defaultTokenCallbackHandlerContract()).attach(safe.address);
             // Check that Safe is NOT setup
             await expect(await safe.getThreshold()).to.be.deep.eq(BigNumber.from(0));
 

--- a/test/core/Safe.StorageAccessible.spec.ts
+++ b/test/core/Safe.StorageAccessible.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { deployments, waffle } from "hardhat";
 import "@nomiclabs/hardhat-ethers";
-import { getSafeSingleton, getDefaultCallbackHandler, getSafeWithOwners } from "../utils/setup";
+import { getSafeSingleton, getSafeWithOwners } from "../utils/setup";
 import { utils } from "ethers";
 import { killLibContract } from "../utils/contracts";
 
@@ -10,12 +10,10 @@ describe("StorageAccessible", async () => {
 
     const setupTests = deployments.createFixture(async ({ deployments }) => {
         await deployments.fixture();
-        const handler = await getDefaultCallbackHandler();
         const killLib = await killLibContract(user1);
         return {
-            safe: await getSafeWithOwners([user1.address, user2.address], 1, handler.address),
+            safe: await getSafeWithOwners([user1.address, user2.address], 1),
             killLib,
-            handler,
         };
     });
 

--- a/test/handlers/TokenCallbackHandler.spec.ts
+++ b/test/handlers/TokenCallbackHandler.spec.ts
@@ -2,62 +2,62 @@ import { expect } from "chai";
 import { deployments } from "hardhat";
 import "@nomiclabs/hardhat-ethers";
 import { AddressZero } from "@ethersproject/constants";
-import { getDefaultCallbackHandler } from "../utils/setup";
+import { getTokenCallbackHandler } from "../utils/setup";
 
-describe("DefaultCallbackHandler", async () => {
+describe("TokenCallbackHandler", async () => {
     beforeEach(async () => {
         await deployments.fixture();
     });
 
     describe("ERC1155", async () => {
         it("should support ERC1155 interface", async () => {
-            const handler = await getDefaultCallbackHandler();
+            const handler = await getTokenCallbackHandler();
             await expect(await handler.callStatic.supportsInterface("0x4e2312e0")).to.be.eq(true);
         });
 
         it("to handle onERC1155Received", async () => {
-            const handler = await getDefaultCallbackHandler();
+            const handler = await getTokenCallbackHandler();
             await expect(await handler.callStatic.onERC1155Received(AddressZero, AddressZero, 0, 0, "0x")).to.be.eq("0xf23a6e61");
         });
 
         it("to handle onERC1155BatchReceived", async () => {
-            const handler = await getDefaultCallbackHandler();
+            const handler = await getTokenCallbackHandler();
             await expect(await handler.callStatic.onERC1155BatchReceived(AddressZero, AddressZero, [], [], "0x")).to.be.eq("0xbc197c81");
         });
     });
 
     describe("ERC721", async () => {
         it("should support ERC721 interface", async () => {
-            const handler = await getDefaultCallbackHandler();
+            const handler = await getTokenCallbackHandler();
             await expect(await handler.callStatic.supportsInterface("0x150b7a02")).to.be.eq(true);
         });
 
         it("to handle onERC721Received", async () => {
-            const handler = await getDefaultCallbackHandler();
+            const handler = await getTokenCallbackHandler();
             await expect(await handler.callStatic.onERC721Received(AddressZero, AddressZero, 0, "0x")).to.be.eq("0x150b7a02");
         });
     });
 
     describe("ERC777", async () => {
         it("to handle tokensReceived", async () => {
-            const handler = await getDefaultCallbackHandler();
+            const handler = await getTokenCallbackHandler();
             await handler.callStatic.tokensReceived(AddressZero, AddressZero, AddressZero, 0, "0x", "0x");
         });
     });
 
     describe("ERC165", async () => {
         it("should support ERC165 interface", async () => {
-            const handler = await getDefaultCallbackHandler();
+            const handler = await getTokenCallbackHandler();
             await expect(await handler.callStatic.supportsInterface("0x01ffc9a7")).to.be.eq(true);
         });
 
         it("should not support random interface", async () => {
-            const handler = await getDefaultCallbackHandler();
+            const handler = await getTokenCallbackHandler();
             await expect(await handler.callStatic.supportsInterface("0xbaddad42")).to.be.eq(false);
         });
 
         it("should not support invalid interface", async () => {
-            const handler = await getDefaultCallbackHandler();
+            const handler = await getTokenCallbackHandler();
             await expect(await handler.callStatic.supportsInterface("0xffffffff")).to.be.eq(false);
         });
     });

--- a/test/integration/Safe.ERC1155.spec.ts
+++ b/test/integration/Safe.ERC1155.spec.ts
@@ -3,7 +3,7 @@ import hre, { deployments, waffle } from "hardhat";
 import { BigNumber } from "ethers";
 import "@nomiclabs/hardhat-ethers";
 import { AddressZero } from "@ethersproject/constants";
-import { defaultCallbackHandlerDeployment, getSafeTemplate } from "../utils/setup";
+import { defaultTokenCallbackHandlerDeployment, getSafeTemplate } from "../utils/setup";
 
 describe("Safe", async () => {
     const mockErc1155 = async () => {
@@ -42,7 +42,7 @@ describe("Safe", async () => {
 
         it("should not reject if callback is accepted", async () => {
             const { safe, token } = await setupWithTemplate();
-            const handler = await defaultCallbackHandlerDeployment();
+            const handler = await defaultTokenCallbackHandlerDeployment();
 
             // Setup Safe
             await safe.setup([user1.address, user2.address], 1, AddressZero, "0x", handler.address, AddressZero, 0, AddressZero);

--- a/test/utils/setup.ts
+++ b/test/utils/setup.ts
@@ -6,12 +6,12 @@ import { logGas } from "../../src/utils/execution";
 import { safeContractUnderTest } from "./config";
 import { getRandomIntAsString } from "./numbers";
 
-export const defaultCallbackHandlerDeployment = async () => {
-    return await deployments.get("DefaultCallbackHandler");
+export const defaultTokenCallbackHandlerDeployment = async () => {
+    return await deployments.get("TokenCallbackHandler");
 };
 
-export const defaultCallbackHandlerContract = async () => {
-    return await hre.ethers.getContractFactory("DefaultCallbackHandler");
+export const defaultTokenCallbackHandlerContract = async () => {
+    return await hre.ethers.getContractFactory("TokenCallbackHandler");
 };
 
 export const compatFallbackHandlerDeployment = async () => {
@@ -92,8 +92,8 @@ export const getSafeWithOwners = async (
     return template;
 };
 
-export const getDefaultCallbackHandler = async () => {
-    return (await defaultCallbackHandlerContract()).attach((await defaultCallbackHandlerDeployment()).address);
+export const getTokenCallbackHandler = async () => {
+    return (await defaultTokenCallbackHandlerContract()).attach((await defaultTokenCallbackHandlerDeployment()).address);
 };
 
 export const getCompatFallbackHandler = async () => {


### PR DESCRIPTION
According to the documentation and code, the sole responsibility of the `DefaultCallbackHandler` is to handle token callbacks. Therefore after a discussion in Slack, we agreed on renaming it to `TokenFallbackHandler`. This PR adjusts the name and associated test/utility code. 