### PR TITLE
Refactor: Make base/common contracts abstract

### DIFF
--- a/contracts/base/Executor.sol
+++ b/contracts/base/Executor.sol
@@ -6,7 +6,7 @@ import "../common/Enum.sol";
  * @title Executor - A contract that can execute transactions
  * @author Richard Meissner - @rmeissner
  */
-contract Executor {
+abstract contract Executor {
     /**
      * @notice Executes either a delegatecall or a call with provided parameters.
      * @param to Destination address.

--- a/contracts/base/FallbackManager.sol
+++ b/contracts/base/FallbackManager.sol
@@ -7,7 +7,7 @@ import "../common/SelfAuthorized.sol";
  * @title Fallback Manager - A contract managing fallback calls made to this contract
  * @author Richard Meissner - @rmeissner
  */
-contract FallbackManager is SelfAuthorized {
+abstract contract FallbackManager is SelfAuthorized {
     event ChangedFallbackHandler(address handler);
 
     // keccak256("fallback_manager.handler.address")

--- a/contracts/base/GuardManager.sol
+++ b/contracts/base/GuardManager.sol
@@ -35,7 +35,7 @@ abstract contract BaseGuard is Guard {
  * @title Guard Manager - A contract managing transaction guards which perform pre and post-checks on Safe transactions.
  * @author Richard Meissner - @rmeissner
  */
-contract GuardManager is SelfAuthorized {
+abstract contract GuardManager is SelfAuthorized {
     event ChangedGuard(address guard);
 
     // keccak256("guard_manager.guard.address")

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -12,7 +12,7 @@ import "./Executor.sol";
  * @author Stefan George - @Georgi87
  * @author Richard Meissner - @rmeissner
  */
-contract ModuleManager is SelfAuthorized, Executor {
+abstract contract ModuleManager is SelfAuthorized, Executor {
     event EnabledModule(address module);
     event DisabledModule(address module);
     event ExecutionFromModuleSuccess(address indexed module);

--- a/contracts/base/OwnerManager.sol
+++ b/contracts/base/OwnerManager.sol
@@ -9,7 +9,7 @@ import "../common/SelfAuthorized.sol";
  * @author Stefan George - @Georgi87
  * @author Richard Meissner - @rmeissner
  */
-contract OwnerManager is SelfAuthorized {
+abstract contract OwnerManager is SelfAuthorized {
     event AddedOwner(address owner);
     event RemovedOwner(address owner);
     event ChangedThreshold(uint256 threshold);

--- a/contracts/common/Enum.sol
+++ b/contracts/common/Enum.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
  * @title Enum - Collection of enums used in Safe contracts.
  * @author Richard Meissner - @rmeissner
  */
-contract Enum {
+abstract contract Enum {
     enum Operation {
         Call,
         DelegateCall

--- a/contracts/common/NativeCurrencyPaymentFallback.sol
+++ b/contracts/common/NativeCurrencyPaymentFallback.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
  * @title EtherPaymentFallback - A contract that has a fallback to accept native currency payments.
  * @author Richard Meissner - @rmeissner
  */
-contract NativeCurrencyPaymentFallback {
+abstract contract NativeCurrencyPaymentFallback {
     event SafeReceived(address indexed sender, uint256 value);
 
     /**

--- a/contracts/common/SecuredTokenTransfer.sol
+++ b/contracts/common/SecuredTokenTransfer.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
  * @title SecuredTokenTransfer - Secure token transfer.
  * @author Richard Meissner - @rmeissner
  */
-contract SecuredTokenTransfer {
+abstract contract SecuredTokenTransfer {
     /**
      * @notice Transfers a token and returns a boolean if it was a success
      * @dev It checks the return data of the transfer call and returns true if the transfer was successful.

--- a/contracts/common/SelfAuthorized.sol
+++ b/contracts/common/SelfAuthorized.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
  * @title SelfAuthorized - Authorizes current contract to perform actions to itself.
  * @author Richard Meissner - @rmeissner
  */
-contract SelfAuthorized {
+abstract contract SelfAuthorized {
     function requireSelfCall() private view {
         require(msg.sender == address(this), "GS031");
     }

--- a/contracts/common/SignatureDecoder.sol
+++ b/contracts/common/SignatureDecoder.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.7.0 <0.9.0;
  * @title SignatureDecoder - Decodes signatures encoded as bytes
  * @author Richard Meissner - @rmeissner
  */
-contract SignatureDecoder {
+abstract contract SignatureDecoder {
     /**
      * @notice Splits signature bytes into `uint8 v, bytes32 r, bytes32 s`.
      * @dev Make sure to perform a bounds check for @param pos, to avoid out of bounds access on @param signatures

--- a/contracts/common/Singleton.sol
+++ b/contracts/common/Singleton.sol
@@ -6,7 +6,7 @@ pragma solidity >=0.7.0 <0.9.0;
  *        This contract is tightly coupled to our proxy contract (see `proxies/SafeProxy.sol`)
  * @author Richard Meissner - @rmeissner
  */
-contract Singleton {
+abstract contract Singleton {
     // singleton always has to be the first declared variable to ensure the same location as in the Proxy contract.
     // It should also always be ensured the address is stored alone (uses a full word)
     address private singleton;

--- a/contracts/common/StorageAccessible.sol
+++ b/contracts/common/StorageAccessible.sol
@@ -7,7 +7,7 @@ pragma solidity >=0.7.0 <0.9.0;
  *         It removes a method from the original contract not needed for the Safe contracts.
  * @author Gnosis Developers
  */
-contract StorageAccessible {
+abstract contract StorageAccessible {
     /**
      * @notice Reads `length` bytes of storage in the currents contract
      * @param offset - the offset in the current contract's storage in words to start reading from

--- a/contracts/handler/HandlerContext.sol
+++ b/contracts/handler/HandlerContext.sol
@@ -8,7 +8,7 @@ pragma solidity >=0.7.0 <0.9.0;
  * based on https://github.com/OpenZeppelin/openzeppelin-contracts/blob/f8cc8b844a9f92f63dc55aa581f7d643a1bc5ac1/contracts/metatx/ERC2771Context.sol
  * @author Richard Meissner - @rmeissner
  */
-contract HandlerContext {
+abstract contract HandlerContext {
     /**
      * @notice Allows fetching the original caller address.
      * @dev This is only reliable in combination with a FallbackManager that supports this (e.g. Safe contract >=1.3.0).


### PR DESCRIPTION
The contracts in `base` and `common` contracts are all pieces of a bigger picture and shouldn't be deployed on their own. This PR makes them abstract contracts.