### PR TITLE
Bump version to 1.4.1, add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 This changelog only contains changes starting from version 1.3.0
 
+# Version 1.4.1
+
+## Compiler settings
+
+Solidity compiler: [0.7.6](https://github.com/ethereum/solidity/releases/tag/v0.7.6) (for more info see issue [#251](https://github.com/safe-global/safe-contracts/issues/251))
+
+Solidity optimizer: `disabled`
+
+## Expected addresses with [Safe Singleton Factory](https://github.com/safe-global/safe-singleton-factory)
+
+### Core contracts
+
+-   `Safe` at `0xc962E67D9490E154D81181879ddf4CD3b65D2132`
+-   `SafeL2` at `0x1eb4681c549d995AbdC4aB189cAbb9f00B508cAb`
+
+### Factory contracts
+
+-   `SafeProxyFactory` at `0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67`
+
+### Handler contracts
+
+-   `TokenCallbackHandler` at `0xeDCF620325E82e3B9836eaaeFdc4283E99Dd7562`
+-   `CompatibilityFallbackHandler` at `0x2a15DE4410d4c8af0A7b6c12803120f43C42B820`
+
+### Lib contracts
+
+-   `MultiSend` at `0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526`
+-   `MultiSendCallOnly` at `0x9641d764fc13c8B624c04430C7356C1C7C8102e2`
+-   `CreateCall` at `0x9b35Af71d77eaf8d7e40252370304687390A1A52`
+-   `SignMessageLib` at `0x58FCe385Ed16beB4BCE49c8DF34c7d6975807520`
+
+### Storage reader contracts
+
+-   `SimulateTxAccessor` at `0x3d4BA2E0884aa488718476ca2FB8Efc291A46199`
+
+## Changes
+
+### Bugfixes
+
+#### Remove `gasleft()` usage in `setupModules`
+
+Issue: [#568](https://github.com/safe-global/safe-contracts/issues/568)
+
+`setupModules` made a call to `gasleft()` that is invalid in the ERC-4337 standard. The call was replaced with `type(uint256).max` to forward all the available gas instead.
+
+
 # Version 1.4.0
 
 ## Compiler settings

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Documentation
 
 Audits/ Formal Verification
 ---------
-- [for Version 1.4.0 by Ackee Blockchain](docs/audit_1_4_0.md)
+- [for Version 1.4.0/1.4.1 by Ackee Blockchain](docs/audit_1_4_0.md)
 - [for Version 1.3.0 by G0 Group](docs/audit_1_3_0.md)
 - [for Version 1.2.0 by G0 Group](docs/audit_1_2_0.md)
 - [for Version 1.1.1 by G0 Group](docs/audit_1_1_1.md)

--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -44,7 +44,7 @@ contract Safe is
 {
     using SafeMath for uint256;
 
-    string public constant VERSION = "1.4.0";
+    string public constant VERSION = "1.4.1";
 
     // keccak256(
     //     "EIP712Domain(uint256 chainId,address verifyingContract)"

--- a/docs/audit_1_4_0.md
+++ b/docs/audit_1_4_0.md
@@ -8,6 +8,13 @@
 
 The final audit was performed on commit [eb93dbb0f62e2dc1b308ac4c110038062df0a8c9](https://github.com/safe-global/safe-contracts/tree/eb93dbb0f62e2dc1b308ac4c110038062df0a8c9).
 
+There has been one minor bugfix after the audit related to ERC-4337 opcode compatibility:
+
+-   [Pull request](https://github.com/safe-global/safe-contracts/pull/572)
+-   [Commit](https://github.com/safe-global/safe-contracts/commit/f8bd2159b64392d5b594f4e056be258ade2fefab)
+
+A change of similar scope has been successfully audited in the 1.4.0 release. Therefore, after notifying the auditors, we concluded no re-audit was necessary.
+
 ##### Files
 
 -   [Final Audit Report 1.4.0](Safe_Audit_Report_1_4_0.pdf)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@safe-global/safe-contracts",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "description": "Ethereum multisig contract",
     "homepage": "https://github.com/safe-global/safe-contracts/",
     "license": "LGPL-3.0",
@@ -46,7 +46,7 @@
     },
     "devDependencies": {
         "@gnosis.pm/mock-contract": "^4.0.0",
-        "@gnosis.pm/safe-singleton-factory": "^1.0.3",
+        "@gnosis.pm/safe-singleton-factory": "^1.0.14",
         "@nomiclabs/hardhat-ethers": "2.0.2",
         "@nomiclabs/hardhat-etherscan": "^3.1.7",
         "@nomiclabs/hardhat-waffle": "2.0.1",

--- a/test/migration/UpgradeFromSafe111.spec.ts
+++ b/test/migration/UpgradeFromSafe111.spec.ts
@@ -33,7 +33,7 @@ describe("Upgrade from Safe 1.1.1", () => {
         const data = ChangeMasterCopyInterface.encodeFunctionData("changeMasterCopy", [singleton140]);
         const tx = buildSafeTransaction({ to: safe.address, data, nonce });
         await executeTx(safe, tx, [await safeApproveHash(user1, safe, tx, true)]);
-        expect(await safe.VERSION()).to.be.eq("1.4.0");
+        expect(await safe.VERSION()).to.be.eq("1.4.1");
 
         return {
             migratedSafe: safe,

--- a/test/migration/UpgradeFromSafe120.spec.ts
+++ b/test/migration/UpgradeFromSafe120.spec.ts
@@ -33,7 +33,7 @@ describe("Upgrade from Safe 1.2.0", () => {
         const data = ChangeMasterCopyInterface.encodeFunctionData("changeMasterCopy", [singleton140]);
         const tx = buildSafeTransaction({ to: safe.address, data, nonce });
         await executeTx(safe, tx, [await safeApproveHash(user1, safe, tx, true)]);
-        expect(await safe.VERSION()).to.be.eq("1.4.0");
+        expect(await safe.VERSION()).to.be.eq("1.4.1");
 
         return {
             migratedSafe: safe,

--- a/yarn.lock
+++ b/yarn.lock
@@ -840,10 +840,10 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/mock-contract/-/mock-contract-4.0.0.tgz#eaf500fddcab81b5f6c22280a7b22ff891dd6f87"
   integrity sha512-SkRq2KwPx6vo0LAjSc8JhgQstrQFXRyn2yqquIfub7r2WHi5nUbF8beeSSXsd36hvBcQxQfmOIYNYRpj9JOhrQ==
 
-"@gnosis.pm/safe-singleton-factory@^1.0.3":
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-singleton-factory/-/safe-singleton-factory-1.0.12.tgz#4a0b373dc5c4097b8166d8747df348a400fb72a7"
-  integrity sha512-7nUnXi35EiVKRxypTJ60UMFaf6xA5TLTYyVur2877RDRU02pTabWx1D0wCbdWBMRE0sAxIe302CbIBdpkZuMIg==
+"@gnosis.pm/safe-singleton-factory@^1.0.14":
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-singleton-factory/-/safe-singleton-factory-1.0.14.tgz#42dae9a91fda21b605f94bfe310a7fccc6a4d738"
+  integrity sha512-xZ26c9uKzpd5Sm8ux0sZHt5QC8n+Q2z1/X5xjPnd8aT5EcKH5t1GgLbAqjrMFmXVIOkiWSc7wi2Bj4XfgtiyaQ==
 
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"


### PR DESCRIPTION
This PR:
- Bumps version to 1.4.1
- Adds a changelog with the expected addresses
- Bumps the factory package version to the latest one for a further smooth deployment experience