### PR TITLE
Formal verification: No message can be signed through the core contract

### DIFF
--- a/certora/specs/Safe.spec
+++ b/certora/specs/Safe.spec
@@ -3,6 +3,7 @@ methods {
     function getThreshold() external returns (uint256) envfree;
     function disableModule(address,address) external;
     function nonce() external returns (uint256) envfree;
+    function signedMessages(bytes32) external returns (uint256) envfree;
 
     // harnessed
     function getModule(address) external returns (address) envfree;
@@ -153,3 +154,7 @@ rule guardAddressChange(method f) filtered {
     assert guardBefore != guardAfter =>
         f.selector == sig:setGuard(address).selector;
 }
+
+invariant noSignedMessages(bytes32 message)
+    signedMessages(message) == 0
+    filtered { f -> reachableOnly(f) }

--- a/certora/specs/Safe.spec
+++ b/certora/specs/Safe.spec
@@ -3,6 +3,7 @@ methods {
     function getThreshold() external returns (uint256) envfree;
     function disableModule(address,address) external;
     function nonce() external returns (uint256) envfree;
+    function signedMessages(bytes32) external returns (uint256) envfree;
 
     // harnessed
     function getModule(address) external returns (address) envfree;
@@ -153,3 +154,6 @@ rule guardAddressChange(method f) filtered {
     assert guardBefore != guardAfter =>
         f.selector == sig:setGuard(address).selector;
 }
+
+invariant noSignedMessages(bytes32 message)
+    signedMessages(message) == 0;


### PR DESCRIPTION
This PR:
- Adds a rule that checks that no message can be signed through the core contract