### PR TITLE
Fix: Certora CI action

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -26,7 +26,7 @@ jobs:
               with: { java-version: "17", java-package: jre, distribution: semeru }
 
             - name: Install certora cli-beta
-              run: pip install certora-cli-beta
+              run: pip install -Iv certora-cli-beta==4.2.0
 
             - name: Install solc
               run: |

--- a/certora/scripts/verifySafe.sh
+++ b/certora/scripts/verifySafe.sh
@@ -10,7 +10,7 @@ certoraRun  certora/harnesses/SafeHarness.sol \
     --verify SafeHarness:certora/specs/Safe.spec \
     --solc solc7.6 \
     --optimistic_loop \
-    --settings -optimisticFallback=true \
+    --prover_args "-optimisticFallback true" \
     --loop_iter 3 \
     --optimistic_hashing \
     --hashing_length_bound 352 \


### PR DESCRIPTION
The certora CI action broke here: https://github.com/safe-global/safe-contracts/pull/590 - [Failed run](https://github.com/safe-global/safe-contracts/actions/runs/5281968539/jobs/9556262248?pr=590)

It broke because the version of the `certora-cli-beta` wasn't pinned, and it installed a new version with breaking changes for the keyword to pass settings to the prover (`settings` changed to `prover_args`). This PR:
- Adjust the keyword
- Pin version on the excellent version number `4.2.0` (the latest available at the moment)