### PR TITLE
Feature: bytecode size reduction by removing public `getChainId` function, making encodeTransactionData private

### DIFF
--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -350,25 +350,18 @@ contract Safe is
     }
 
     /**
-     * @notice Returns the ID of the chain the contract is currently deployed on.
-     * @return The ID of the current chain as a uint256.
-     */
-    function getChainId() public view returns (uint256) {
-        uint256 id;
-        // solhint-disable-next-line no-inline-assembly
-        /// @solidity memory-safe-assembly
-        assembly {
-            id := chainid()
-        }
-        return id;
-    }
-
-    /**
      * @dev Returns the domain separator for this contract, as defined in the EIP-712 standard.
      * @return bytes32 The domain separator hash.
      */
     function domainSeparator() public view returns (bytes32) {
-        return keccak256(abi.encode(DOMAIN_SEPARATOR_TYPEHASH, getChainId(), this));
+        uint256 chainId;
+        // solhint-disable-next-line no-inline-assembly
+        /// @solidity memory-safe-assembly
+        assembly {
+            chainId := chainid()
+        }
+
+        return keccak256(abi.encode(DOMAIN_SEPARATOR_TYPEHASH, chainId, this));
     }
 
     /**
@@ -396,7 +389,7 @@ contract Safe is
         address gasToken,
         address refundReceiver,
         uint256 _nonce
-    ) public view returns (bytes memory) {
+    ) private view returns (bytes memory) {
         bytes32 safeTxHash = keccak256(
             abi.encode(
                 SAFE_TX_TYPEHASH,

--- a/test/core/Safe.Signatures.spec.ts
+++ b/test/core/Safe.Signatures.spec.ts
@@ -58,13 +58,6 @@ describe("Safe", async () => {
         });
     });
 
-    describe("getChainId", async () => {
-        it("should return correct id", async () => {
-            const { safe } = await setupTests();
-            expect(await safe.getChainId()).to.be.eq(await chainId());
-        });
-    });
-
     describe("approveHash", async () => {
         it("approving should only be allowed for owners", async () => {
             const { safe } = await setupTests();

--- a/test/integration/Safe.0xExploit.spec.ts
+++ b/test/integration/Safe.0xExploit.spec.ts
@@ -40,8 +40,8 @@ describe("Safe", async () => {
             const nonce = await safe.nonce();
 
             // Use off-chain Safe signature
-            const messageData = await safe.encodeTransactionData(to, value, data, operation, 0, 0, 0, AddressZero, AddressZero, nonce);
-            const messageHash = await messageHandler.getMessageHash(ethers.utils.keccak256(messageData));
+            const transactionHash = await safe.getTransactionHash(to, value, data, operation, 0, 0, 0, AddressZero, AddressZero, nonce);
+            const messageHash = await messageHandler.getMessageHash(transactionHash);
             const ownerSigs = await buildSignatureBytes([await signHash(user1, messageHash), await signHash(user2, messageHash)]);
             const encodedOwnerSigns = defaultAbiCoder.encode(["bytes"], [ownerSigs]).slice(66);
 
@@ -111,8 +111,8 @@ describe("Safe", async () => {
             const nonce = await safe.nonce();
 
             // Use off-chain Safe signature
-            const messageData = await safe.encodeTransactionData(to, value, data, operation, 0, 0, 0, AddressZero, AddressZero, nonce);
-            const messageHash = await messageHandler.getMessageHash(messageData);
+            const transactionHash = await safe.getTransactionHash(to, value, data, operation, 0, 0, 0, AddressZero, AddressZero, nonce);
+            const messageHash = await messageHandler.getMessageHash(transactionHash);
             const ownerSigs = await buildSignatureBytes([await signHash(user1, messageHash), await signHash(user2, messageHash)]);
             const encodedOwnerSigns = defaultAbiCoder.encode(["bytes"], [ownerSigs]).slice(66);
 


### PR DESCRIPTION
This PR is a pre-requisite for future 1.5.0 features like the overloaded `checkNSignatures` and the module guard.

Code size after all the changes:
```
Safe 22913 bytes (limit is 24576)
SafeL2 23755 bytes (limit is 24576)
```