### PR TITLE
Formal verification: Add a rule for enabling modules

### DIFF
--- a/certora/specs/Safe.spec
+++ b/certora/specs/Safe.spec
@@ -271,3 +271,15 @@ rule safeOwnerCountConsistency(method f) filtered {
 
     assert getOwnersCount() == getOwnersCountFromArray();
 }
+
+rule moduleOnlyAddedThroughEnableModule(method f, address module) filtered {
+    f -> reachableOnly(f)
+} {
+    require getModule(module) == 0;
+
+    calldataarg args; env e;
+    f(e, args);
+
+    assert getModule(module) != 0 => 
+        f.selector == sig:enableModule(address).selector;
+}


### PR DESCRIPTION
This PR:
- adds a rule that checks that the module can only be added through `enableModule`