### PR TITLE
Formal verification: Fix unresolved setup call from the harness constructor

### DIFF
--- a/certora/applyHarness.patch
+++ b/certora/applyHarness.patch
@@ -1,6 +1,40 @@
+diff -druN Safe.sol Safe.sol
+--- Safe.sol	2023-08-16 17:09:10
++++ Safe.sol	2023-08-25 11:14:11
+@@ -75,7 +75,7 @@
+          * so we create a Safe with 0 owners and threshold 1.
+          * This is an unusable Safe, perfect for the singleton
+          */
+-        threshold = 1;
++        // threshold = 1; MUNGED: remove and add to constructor of the harness
+     }
+ 
+     /**
+@@ -92,15 +92,18 @@
+      * @param paymentReceiver Address that should receive the payment (or 0 if tx.origin)
+      */
+     function setup(
+-        address[] calldata _owners,
++        address[] memory _owners,
+         uint256 _threshold,
+         address to,
+-        bytes calldata data,
++        bytes memory data,
+         address fallbackHandler,
+         address paymentToken,
+         uint256 payment,
+         address payable paymentReceiver
+-    ) external {
++    ) public {
++        // MUNGED: had to change the method visibility and location of the variables to be able to call it from the harness
++        // constructor.
++         
+         // setupOwners checks if the Threshold is already set, therefore preventing that this method is called twice
+         setupOwners(_owners, _threshold);
+         if (fallbackHandler != address(0)) internalSetFallbackHandler(fallbackHandler);
 diff -druN base/Executor.sol base/Executor.sol
---- base/Executor.sol	2023-06-30 15:32:21.392860349 +0200
-+++ base/Executor.sol	2023-06-30 15:37:58.671801994 +0200
+--- base/Executor.sol	2023-08-16 17:09:10
++++ base/Executor.sol	2023-08-25 11:11:53
 @@ -26,11 +26,8 @@
          uint256 txGas
      ) internal returns (bool success) {
@@ -15,15 +49,3 @@ diff -druN base/Executor.sol base/Executor.sol
          } else {
              // solhint-disable-next-line no-inline-assembly
              /// @solidity memory-safe-assembly
-diff -druN Safe.sol Safe.sol
---- Safe.sol	2023-06-30 15:32:21.392860349 +0200
-+++ Safe.sol	2023-06-30 15:37:17.198953773 +0200
-@@ -76,7 +76,7 @@
-          * so we create a Safe with 0 owners and threshold 1.
-          * This is an unusable Safe, perfect for the singleton
-          */
--        threshold = 1;
-+        // threshold = 1; MUNGED: remove and add to constructor of the harness
-     }
- 
-     /**

--- a/certora/harnesses/SafeHarness.sol
+++ b/certora/harnesses/SafeHarness.sol
@@ -12,7 +12,7 @@ contract SafeHarness is Safe {
         uint256 payment,
         address payable paymentReceiver
     ) {
-        this.setup(_owners, _threshold, to, data, fallbackHandler, paymentToken, payment, paymentReceiver);
+        setup(_owners, _threshold, to, data, fallbackHandler, paymentToken, payment, paymentReceiver);
     }
 
     // harnessed getters


### PR DESCRIPTION
While debugging our failed runs in https://github.com/safe-global/safe-contracts/pull/641, @jhoenicke pointed out in our shared Slack channel, that there was an unresolved call in the constructor method. There was a solidity compiler warning, but I previously checked this with the Certora team, and they deemed this one OK in the prover context. 

This PR fixes it by munging the visibility from external to public for the setup method and also adjusting the storage location of the variables passed to the method to be callable from the constructor.

Many thanks to @jhoenicke 🙂