### PR TITLE
Use byte instead of and in the SignatureDecoderContract

### DIFF
--- a/contracts/common/SignatureDecoder.sol
+++ b/contracts/common/SignatureDecoder.sol
@@ -25,13 +25,7 @@ abstract contract SignatureDecoder {
             let signaturePos := mul(0x41, pos)
             r := mload(add(signatures, add(signaturePos, 0x20)))
             s := mload(add(signatures, add(signaturePos, 0x40)))
-            /**
-             * Here we are loading the last 32 bytes, including 31 bytes
-             * of 's'. There is no 'mload8' to do this.
-             * 'byte' is not working due to the Solidity parser, so lets
-             * use the second best option, 'and'
-             */
-            v := and(mload(add(signatures, add(signaturePos, 0x41))), 0xff)
+            v := byte(0, mload(add(signatures, add(signaturePos, 0x60))))
         }
     }
 }


### PR DESCRIPTION
@roleengineer suggested that we could use `byte` instead of `and` in the signature split function. After reviewing the "industry standards" contracts, that seems to be a good decision (e.g., https://github.com/OpenZeppelin/openzeppelin-contracts/blob/a5ed318634016a25be4000ee07044a31f363e60c/contracts/utils/cryptography/ECDSA.sol#L53-L70)

This PR makes the adjustment. 