### PR TITLE
Fix: Solidity linter errors

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -12,6 +12,7 @@
         "not-rely-on-time": "off",
         "reason-string": "off",
         "no-empty-blocks": "off",
-        "avoid-low-level-calls": "off"
+        "avoid-low-level-calls": "off",
+        "custom-errors": "off"
     }
 }

--- a/certora/applyHarness.patch
+++ b/certora/applyHarness.patch
@@ -1,7 +1,7 @@
 diff -druN Safe.sol Safe.sol
---- Safe.sol	2023-08-16 17:09:10
-+++ Safe.sol	2023-08-25 11:14:11
-@@ -75,7 +75,7 @@
+--- Safe.sol	2023-08-30 20:37:09
++++ Safe.sol	2023-08-30 20:45:31
+@@ -76,7 +76,7 @@
           * so we create a Safe with 0 owners and threshold 1.
           * This is an unusable Safe, perfect for the singleton
           */
@@ -10,7 +10,7 @@ diff -druN Safe.sol Safe.sol
      }
  
      /**
-@@ -92,15 +92,18 @@
+@@ -93,15 +93,18 @@
       * @param paymentReceiver Address that should receive the payment (or 0 if tx.origin)
       */
      function setup(
@@ -33,19 +33,20 @@ diff -druN Safe.sol Safe.sol
          setupOwners(_owners, _threshold);
          if (fallbackHandler != address(0)) internalSetFallbackHandler(fallbackHandler);
 diff -druN base/Executor.sol base/Executor.sol
---- base/Executor.sol	2023-08-16 17:09:10
-+++ base/Executor.sol	2023-08-25 11:11:53
-@@ -26,11 +26,8 @@
+--- base/Executor.sol	2023-08-30 20:06:21
++++ base/Executor.sol	2023-08-30 20:47:47
+@@ -26,12 +26,8 @@
          uint256 txGas
      ) internal returns (bool success) {
          if (operation == Enum.Operation.DelegateCall) {
--            // solhint-disable-next-line no-inline-assembly
+-            /* solhint-disable no-inline-assembly */
 -            /// @solidity memory-safe-assembly
 -            assembly {
 -                success := delegatecall(txGas, to, add(data, 0x20), mload(data), 0, 0)
 -            }
+-            /* solhint-enable no-inline-assembly */
 +            // MUNGED lets just be a bit more optimistic, `execute` does nothing for `DELEGATECALL` and always returns true
 +            return true;
          } else {
-             // solhint-disable-next-line no-inline-assembly
+             /* solhint-disable no-inline-assembly */
              /// @solidity memory-safe-assembly

--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -1,17 +1,18 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import "./base/ModuleManager.sol";
-import "./base/OwnerManager.sol";
-import "./base/FallbackManager.sol";
-import "./base/GuardManager.sol";
-import "./common/NativeCurrencyPaymentFallback.sol";
-import "./common/Singleton.sol";
-import "./common/SignatureDecoder.sol";
-import "./common/SecuredTokenTransfer.sol";
-import "./common/StorageAccessible.sol";
-import "./interfaces/ISignatureValidator.sol";
-import "./external/SafeMath.sol";
+import {Guard} from "./base/GuardManager.sol";
+import {ModuleManager} from "./base/ModuleManager.sol";
+import {OwnerManager} from "./base/OwnerManager.sol";
+import {FallbackManager} from "./base/FallbackManager.sol";
+import {NativeCurrencyPaymentFallback} from "./common/NativeCurrencyPaymentFallback.sol";
+import {Singleton} from "./common/Singleton.sol";
+import {SignatureDecoder} from "./common/SignatureDecoder.sol";
+import {SecuredTokenTransfer} from "./common/SecuredTokenTransfer.sol";
+import {StorageAccessible} from "./common/StorageAccessible.sol";
+import {Enum} from "./common/Enum.sol";
+import {ISignatureValidator, ISignatureValidatorConstants} from "./interfaces/ISignatureValidator.sol";
+import {SafeMath} from "./external/SafeMath.sol";
 
 /**
  * @title Safe - A multisignature wallet with support for confirmations using signed messages based on EIP-712.
@@ -307,21 +308,23 @@ contract Safe is
 
                 // Check if the contract signature is in bounds: start of data is s + 32 and end is start + signature length
                 uint256 contractSignatureLen;
-                // solhint-disable-next-line no-inline-assembly
+                /* solhint-disable no-inline-assembly */
                 /// @solidity memory-safe-assembly
                 assembly {
                     contractSignatureLen := mload(add(add(signatures, s), 0x20))
                 }
+                /* solhint-enable no-inline-assembly */
                 require(uint256(s).add(32).add(contractSignatureLen) <= signatures.length, "GS023");
 
                 // Check signature
                 bytes memory contractSignature;
-                // solhint-disable-next-line no-inline-assembly
+                /* solhint-disable no-inline-assembly */
                 /// @solidity memory-safe-assembly
                 assembly {
                     // The signature data for contract signatures is appended to the concatenated signatures and the offset is stored in s
                     contractSignature := add(add(signatures, s), 0x20)
                 }
+                /* solhint-enable no-inline-assembly */
                 require(ISignatureValidator(currentOwner).isValidSignature(dataHash, contractSignature) == EIP1271_MAGIC_VALUE, "GS024");
             } else if (v == 1) {
                 // If v is 1 then it is an approved hash
@@ -361,11 +364,12 @@ contract Safe is
      */
     function domainSeparator() public view returns (bytes32) {
         uint256 chainId;
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             chainId := chainid()
         }
+        /* solhint-enable no-inline-assembly */
 
         return keccak256(abi.encode(DOMAIN_SEPARATOR_TYPEHASH, chainId, this));
     }

--- a/contracts/SafeL2.sol
+++ b/contracts/SafeL2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import "./Safe.sol";
+import {Safe, Enum} from "./Safe.sol";
 
 /**
  * @title SafeL2 - An implementation of the Safe contract that emits additional events on transaction executions.

--- a/contracts/accessors/SimulateTxAccessor.sol
+++ b/contracts/accessors/SimulateTxAccessor.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import "../base/Executor.sol";
+import {Executor, Enum} from "../base/Executor.sol";
 
 /**
  * @title Simulate Transaction Accessor.
@@ -9,10 +9,10 @@ import "../base/Executor.sol";
  * @author Richard Meissner - @rmeissner
  */
 contract SimulateTxAccessor is Executor {
-    address private immutable accessorSingleton;
+    address private immutable ACCESSOR_SINGLETON;
 
     constructor() {
-        accessorSingleton = address(this);
+        ACCESSOR_SINGLETON = address(this);
     }
 
     /**
@@ -20,7 +20,7 @@ contract SimulateTxAccessor is Executor {
      * If the function is called via a regular call, it will revert.
      */
     modifier onlyDelegateCall() {
-        require(address(this) != accessorSingleton, "SimulateTxAccessor should only be called via delegatecall");
+        require(address(this) != ACCESSOR_SINGLETON, "SimulateTxAccessor should only be called via delegatecall");
         _;
     }
 
@@ -48,7 +48,7 @@ contract SimulateTxAccessor is Executor {
         uint256 startGas = gasleft();
         success = execute(to, value, data, operation, gasleft());
         estimate = startGas - gasleft();
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             // Load free memory location
@@ -63,5 +63,6 @@ contract SimulateTxAccessor is Executor {
             // Point the return data to the correct memory location
             returnData := ptr
         }
+        /* solhint-enable no-inline-assembly */
     }
 }

--- a/contracts/base/Executor.sol
+++ b/contracts/base/Executor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
-import "../common/Enum.sol";
+import {Enum} from "../common/Enum.sol";
 
 /**
  * @title Executor - A contract that can execute transactions
@@ -26,17 +26,19 @@ abstract contract Executor {
         uint256 txGas
     ) internal returns (bool success) {
         if (operation == Enum.Operation.DelegateCall) {
-            // solhint-disable-next-line no-inline-assembly
+            /* solhint-disable no-inline-assembly */
             /// @solidity memory-safe-assembly
             assembly {
                 success := delegatecall(txGas, to, add(data, 0x20), mload(data), 0, 0)
             }
+            /* solhint-enable no-inline-assembly */
         } else {
-            // solhint-disable-next-line no-inline-assembly
+            /* solhint-disable no-inline-assembly */
             /// @solidity memory-safe-assembly
             assembly {
                 success := call(txGas, to, value, add(data, 0x20), mload(data), 0, 0)
             }
+            /* solhint-enable no-inline-assembly */
         }
     }
 }

--- a/contracts/base/FallbackManager.sol
+++ b/contracts/base/FallbackManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import "../common/SelfAuthorized.sol";
+import {SelfAuthorized} from "../common/SelfAuthorized.sol";
 
 /**
  * @title Fallback Manager - A contract managing fallback calls made to this contract
@@ -34,11 +34,12 @@ abstract contract FallbackManager is SelfAuthorized {
         require(handler != address(this), "GS400");
 
         bytes32 slot = FALLBACK_HANDLER_STORAGE_SLOT;
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             sstore(slot, handler)
         }
+        /* solhint-enable no-inline-assembly */
     }
 
     /**
@@ -61,7 +62,7 @@ abstract contract FallbackManager is SelfAuthorized {
     // solhint-disable-next-line payable-fallback,no-complex-fallback
     fallback() external {
         bytes32 slot = FALLBACK_HANDLER_STORAGE_SLOT;
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             // When compiled with the optimizer, the compiler relies on a certain assumptions on how the
@@ -96,5 +97,6 @@ abstract contract FallbackManager is SelfAuthorized {
             }
             return(returnDataPtr, returndatasize())
         }
+        /* solhint-enable no-inline-assembly */
     }
 }

--- a/contracts/base/GuardManager.sol
+++ b/contracts/base/GuardManager.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
+/* solhint-disable one-contract-per-file */
 pragma solidity >=0.7.0 <0.9.0;
 
-import "../common/Enum.sol";
-import "../common/SelfAuthorized.sol";
-import "../interfaces/IERC165.sol";
+import {Enum} from "../common/Enum.sol";
+import {SelfAuthorized} from "../common/SelfAuthorized.sol";
+import {IERC165} from "../interfaces/IERC165.sol";
 
 /// @title Guard Interface
 interface Guard is IERC165 {
@@ -89,11 +90,12 @@ abstract contract GuardManager is SelfAuthorized {
             require(Guard(guard).supportsInterface(type(Guard).interfaceId), "GS300");
         }
         bytes32 slot = GUARD_STORAGE_SLOT;
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             sstore(slot, guard)
         }
+        /* solhint-enable no-inline-assembly */
         emit ChangedGuard(guard);
     }
 
@@ -106,10 +108,11 @@ abstract contract GuardManager is SelfAuthorized {
      */
     function getGuard() internal view returns (address guard) {
         bytes32 slot = GUARD_STORAGE_SLOT;
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             guard := sload(slot)
         }
+        /* solhint-enable no-inline-assembly */
     }
 }

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
-import "../common/Enum.sol";
-import "../common/SelfAuthorized.sol";
-import "./Executor.sol";
-import "./GuardManager.sol";
+import {Enum} from "../common/Enum.sol";
+import {SelfAuthorized} from "../common/SelfAuthorized.sol";
+import {Executor} from "./Executor.sol";
+import {GuardManager, Guard} from "./GuardManager.sol";
 
 /**
  * @title Module Manager - A contract managing Safe modules
@@ -119,7 +119,7 @@ abstract contract ModuleManager is SelfAuthorized, Executor, GuardManager {
         Enum.Operation operation
     ) public returns (bool success, bytes memory returnData) {
         success = execTransactionFromModule(to, value, data, operation);
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             // Load free memory location
@@ -134,6 +134,7 @@ abstract contract ModuleManager is SelfAuthorized, Executor, GuardManager {
             // Point the return data to the correct memory location
             returnData := ptr
         }
+        /* solhint-enable no-inline-assembly */
     }
 
     /**
@@ -180,11 +181,12 @@ abstract contract ModuleManager is SelfAuthorized, Executor, GuardManager {
             next = array[moduleCount - 1];
         }
         // Set correct size of returned array
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             mstore(array, moduleCount)
         }
+        /* solhint-enable no-inline-assembly */
     }
 
     /**
@@ -195,11 +197,12 @@ abstract contract ModuleManager is SelfAuthorized, Executor, GuardManager {
      */
     function isContract(address account) internal view returns (bool) {
         uint256 size;
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             size := extcodesize(account)
         }
+        /* solhint-enable no-inline-assembly */
         return size > 0;
     }
 }

--- a/contracts/base/OwnerManager.sol
+++ b/contracts/base/OwnerManager.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
-import "../common/SelfAuthorized.sol";
+import {SelfAuthorized} from "../common/SelfAuthorized.sol";
 
 /**
  * @title OwnerManager - Manages Safe owners and a threshold to authorize transactions.

--- a/contracts/common/SecuredTokenTransfer.sol
+++ b/contracts/common/SecuredTokenTransfer.sol
@@ -19,7 +19,6 @@ abstract contract SecuredTokenTransfer {
         // 0xa9059cbb - keccack("transfer(address,uint256)")
         bytes memory data = abi.encodeWithSelector(0xa9059cbb, receiver, amount);
         // solhint-disable-next-line no-inline-assembly
-        /// @solidity memory-safe-assembly
         assembly {
             // We write the return value to scratch space.
             // See https://docs.soliditylang.org/en/v0.7.6/internals/layout_in_memory.html#layout-in-memory

--- a/contracts/common/SignatureDecoder.sol
+++ b/contracts/common/SignatureDecoder.sol
@@ -19,7 +19,7 @@ abstract contract SignatureDecoder {
      * @return s Output value s of the signature.
      */
     function signatureSplit(bytes memory signatures, uint256 pos) internal pure returns (uint8 v, bytes32 r, bytes32 s) {
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             let signaturePos := mul(0x41, pos)
@@ -27,5 +27,6 @@ abstract contract SignatureDecoder {
             s := mload(add(signatures, add(signaturePos, 0x40)))
             v := byte(0, mload(add(signatures, add(signaturePos, 0x60))))
         }
+        /* solhint-enable no-inline-assembly */
     }
 }

--- a/contracts/common/StorageAccessible.sol
+++ b/contracts/common/StorageAccessible.sol
@@ -17,12 +17,13 @@ abstract contract StorageAccessible {
     function getStorageAt(uint256 offset, uint256 length) public view returns (bytes memory) {
         bytes memory result = new bytes(length * 32);
         for (uint256 index = 0; index < length; index++) {
-            // solhint-disable-next-line no-inline-assembly
+            /* solhint-disable no-inline-assembly */
             /// @solidity memory-safe-assembly
             assembly {
                 let word := sload(add(offset, index))
                 mstore(add(add(result, 0x20), mul(index, 0x20)), word)
             }
+            /* solhint-enable no-inline-assembly */
         }
         return result;
     }
@@ -39,7 +40,7 @@ abstract contract StorageAccessible {
      * @param calldataPayload Calldata that should be sent to the target contract (encoded method name and arguments).
      */
     function simulateAndRevert(address targetContract, bytes memory calldataPayload) external {
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             let success := delegatecall(gas(), targetContract, add(calldataPayload, 0x20), mload(calldataPayload), 0, 0)
@@ -50,5 +51,6 @@ abstract contract StorageAccessible {
             returndatacopy(add(ptr, 0x40), 0, returndatasize())
             revert(ptr, add(returndatasize(), 0x40))
         }
+        /* solhint-enable no-inline-assembly */
     }
 }

--- a/contracts/examples/guards/DebugTransactionGuard.sol
+++ b/contracts/examples/guards/DebugTransactionGuard.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import "../../common/Enum.sol";
-import "../../base/GuardManager.sol";
-import "../../Safe.sol";
+import {Enum} from "../../common/Enum.sol";
+import {BaseGuard} from "../../base/GuardManager.sol";
+import {Safe} from "../../Safe.sol";
 
 /**
  * @title Debug Transaction Guard - Emits transaction events with extended information.

--- a/contracts/examples/guards/DelegateCallTransactionGuard.sol
+++ b/contracts/examples/guards/DelegateCallTransactionGuard.sol
@@ -1,19 +1,18 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import "../../common/Enum.sol";
-import "../../base/GuardManager.sol";
-import "../../Safe.sol";
+import {Enum} from "../../common/Enum.sol";
+import {BaseGuard} from "../../base/GuardManager.sol";
 
 /**
  * @title DelegateCallTransactionGuard - Limits delegate calls to a specific target.
  * @author Richard Meissner - @rmeissner
  */
 contract DelegateCallTransactionGuard is BaseGuard {
-    address public immutable allowedTarget;
+    address public immutable ALLOWED_TARGET;
 
     constructor(address target) {
-        allowedTarget = target;
+        ALLOWED_TARGET = target;
     }
 
     // solhint-disable-next-line payable-fallback
@@ -42,7 +41,7 @@ contract DelegateCallTransactionGuard is BaseGuard {
         bytes memory,
         address
     ) external view override {
-        require(operation != Enum.Operation.DelegateCall || to == allowedTarget, "This call is restricted");
+        require(operation != Enum.Operation.DelegateCall || to == ALLOWED_TARGET, "This call is restricted");
     }
 
     function checkAfterExecution(bytes32, bool) external view override {}
@@ -62,7 +61,7 @@ contract DelegateCallTransactionGuard is BaseGuard {
         Enum.Operation operation,
         address module
     ) external view override returns (bytes32 moduleTxHash) {
-        require(operation != Enum.Operation.DelegateCall || to == allowedTarget, "This call is restricted");
+        require(operation != Enum.Operation.DelegateCall || to == ALLOWED_TARGET, "This call is restricted");
         moduleTxHash = keccak256(abi.encodePacked(to, value, data, operation, module));
     }
 }

--- a/contracts/examples/guards/OnlyOwnersGuard.sol
+++ b/contracts/examples/guards/OnlyOwnersGuard.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
+/* solhint-disable one-contract-per-file */
 pragma solidity >=0.7.0 <0.9.0;
 
-import "../../common/Enum.sol";
-import "../../base/GuardManager.sol";
-import "../../Safe.sol";
+import {Enum} from "../../common/Enum.sol";
+import {BaseGuard} from "../../base/GuardManager.sol";
 
 interface ISafe {
     function getOwners() external view returns (address[] memory);

--- a/contracts/examples/guards/ReentrancyTransactionGuard.sol
+++ b/contracts/examples/guards/ReentrancyTransactionGuard.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import "../../common/Enum.sol";
-import "../../base/GuardManager.sol";
-import "../../Safe.sol";
+import {Enum} from "../../common/Enum.sol";
+import {BaseGuard} from "../../base/GuardManager.sol";
 
 /**
  * @title ReentrancyTransactionGuard - Prevents reentrancy into the transaction execution function.
@@ -29,11 +28,12 @@ contract ReentrancyTransactionGuard is BaseGuard {
      */
     function getGuard() internal pure returns (GuardValue storage guard) {
         bytes32 slot = GUARD_STORAGE_SLOT;
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             guard.slot := slot
         }
+        /* solhint-enable no-inline-assembly */
     }
 
     /**

--- a/contracts/examples/libraries/Migrate_1_3_0_to_1_2_0.sol
+++ b/contracts/examples/libraries/Migrate_1_3_0_to_1_2_0.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
-import "../../libraries/SafeStorage.sol";
+import {SafeStorage} from "../../libraries/SafeStorage.sol";
 
 /**
  * @title Migration - Migrates a Safe contract from 1.3.0 to 1.2.0
@@ -9,14 +9,14 @@ import "../../libraries/SafeStorage.sol";
 contract Migration is SafeStorage {
     bytes32 private constant DOMAIN_SEPARATOR_TYPEHASH = 0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749;
 
-    address public immutable migrationSingleton;
-    address public immutable safe120Singleton;
+    address public immutable MIGRATION_SINGLETON;
+    address public immutable SAFE_120_SINGLETON;
 
     constructor(address targetSingleton) {
         // Singleton address cannot be zero address.
         require(targetSingleton != address(0), "Invalid singleton address provided");
-        safe120Singleton = targetSingleton;
-        migrationSingleton = address(this);
+        SAFE_120_SINGLETON = targetSingleton;
+        MIGRATION_SINGLETON = address(this);
     }
 
     event ChangedMasterCopy(address singleton);
@@ -26,9 +26,9 @@ contract Migration is SafeStorage {
      * @dev This can only be called via a delegatecall.
      */
     function migrate() public {
-        require(address(this) != migrationSingleton, "Migration should only be called via delegatecall");
+        require(address(this) != MIGRATION_SINGLETON, "Migration should only be called via delegatecall");
 
-        singleton = safe120Singleton;
+        singleton = SAFE_120_SINGLETON;
         _deprecatedDomainSeparator = keccak256(abi.encode(DOMAIN_SEPARATOR_TYPEHASH, this));
         emit ChangedMasterCopy(singleton);
     }

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import "./TokenCallbackHandler.sol";
-import "../interfaces/ISignatureValidator.sol";
-import "../Safe.sol";
-import "./HandlerContext.sol";
+import {TokenCallbackHandler} from "./TokenCallbackHandler.sol";
+import {ISignatureValidator} from "../interfaces/ISignatureValidator.sol";
+import {Safe} from "../Safe.sol";
+import {HandlerContext} from "./HandlerContext.sol";
 
 /**
  * @title Compatibility Fallback Handler - Provides compatibility between pre 1.3.0 and 1.3.0+ Safe contracts.
@@ -94,7 +94,7 @@ contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidat
         targetContract;
         calldataPayload;
 
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             let internalCalldata := mload(0x40)
@@ -154,6 +154,7 @@ contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidat
                 revert(add(response, 0x20), mload(response))
             }
         }
+        /* solhint-enable no-inline-assembly */
     }
 
     /**

--- a/contracts/handler/HandlerContext.sol
+++ b/contracts/handler/HandlerContext.sol
@@ -19,11 +19,12 @@ abstract contract HandlerContext {
      */
     function _msgSender() internal pure returns (address sender) {
         // The assembly code is more direct than the Solidity version using `abi.decode`.
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             sender := shr(96, calldataload(sub(calldatasize(), 20)))
         }
+        /* solhint-enable no-inline-assembly */
     }
 
     /**

--- a/contracts/handler/TokenCallbackHandler.sol
+++ b/contracts/handler/TokenCallbackHandler.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import "../interfaces/ERC1155TokenReceiver.sol";
-import "../interfaces/ERC721TokenReceiver.sol";
-import "../interfaces/ERC777TokensRecipient.sol";
-import "../interfaces/IERC165.sol";
+import {ERC1155TokenReceiver} from "../interfaces/ERC1155TokenReceiver.sol";
+import {ERC721TokenReceiver} from "../interfaces/ERC721TokenReceiver.sol";
+import {ERC777TokensRecipient} from "../interfaces/ERC777TokensRecipient.sol";
+import {IERC165} from "../interfaces/IERC165.sol";
 
 /**
  * @title Default Callback Handler - Handles supported tokens' callbacks, allowing Safes receiving these tokens.

--- a/contracts/interfaces/ISignatureValidator.sol
+++ b/contracts/interfaces/ISignatureValidator.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
+/* solhint-disable one-contract-per-file */
 pragma solidity >=0.7.0 <0.9.0;
 
 contract ISignatureValidatorConstants {

--- a/contracts/libraries/CreateCall.sol
+++ b/contracts/libraries/CreateCall.sol
@@ -19,11 +19,12 @@ contract CreateCall {
      * @return newContract The address of the newly created contract.
      */
     function performCreate2(uint256 value, bytes memory deploymentData, bytes32 salt) public returns (address newContract) {
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             newContract := create2(value, add(0x20, deploymentData), mload(deploymentData), salt)
         }
+        /* solhint-enable no-inline-assembly */
         require(newContract != address(0), "Could not deploy contract");
         emit ContractCreation(newContract);
     }
@@ -35,11 +36,12 @@ contract CreateCall {
      * @return newContract The address of the newly created contract.
      */
     function performCreate(uint256 value, bytes memory deploymentData) public returns (address newContract) {
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             newContract := create(value, add(deploymentData, 0x20), mload(deploymentData))
         }
+        /* solhint-enable no-inline-assembly */
         require(newContract != address(0), "Could not deploy contract");
         emit ContractCreation(newContract);
     }

--- a/contracts/libraries/MultiSend.sol
+++ b/contracts/libraries/MultiSend.sol
@@ -9,10 +9,10 @@ pragma solidity >=0.7.0 <0.9.0;
  * @author Richard Meissner - @rmeissner
  */
 contract MultiSend {
-    address private immutable multisendSingleton;
+    address private immutable MULTISEND_SINGLETON;
 
     constructor() {
-        multisendSingleton = address(this);
+        MULTISEND_SINGLETON = address(this);
     }
 
     /**
@@ -28,8 +28,8 @@ contract MultiSend {
      *         If the calling method (e.g. execTransaction) received ETH this would revert otherwise
      */
     function multiSend(bytes memory transactions) public payable {
-        require(address(this) != multisendSingleton, "MultiSend should only be called via delegatecall");
-        // solhint-disable-next-line no-inline-assembly
+        require(address(this) != MULTISEND_SINGLETON, "MultiSend should only be called via delegatecall");
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             let length := mload(transactions)
@@ -69,5 +69,6 @@ contract MultiSend {
                 i := add(i, add(0x55, dataLength))
             }
         }
+        /* solhint-enable no-inline-assembly */
     }
 }

--- a/contracts/libraries/MultiSendCallOnly.sol
+++ b/contracts/libraries/MultiSendCallOnly.sol
@@ -23,7 +23,7 @@ contract MultiSendCallOnly {
      *         If the calling method (e.g. execTransaction) received ETH this would revert otherwise
      */
     function multiSend(bytes memory transactions) public payable {
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             let length := mload(transactions)
@@ -64,5 +64,6 @@ contract MultiSendCallOnly {
                 i := add(i, add(0x55, dataLength))
             }
         }
+        /* solhint-enable no-inline-assembly */
     }
 }

--- a/contracts/libraries/SignMessageLib.sol
+++ b/contracts/libraries/SignMessageLib.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import "./SafeStorage.sol";
-import "../Safe.sol";
+import {SafeStorage} from "./SafeStorage.sol";
+import {Safe} from "../Safe.sol";
 
 /**
  * @title SignMessageLib - Allows to sign messages on-chain by writing the signed message hashes on-chain.

--- a/contracts/proxies/IProxyCreationCallback.sol
+++ b/contracts/proxies/IProxyCreationCallback.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
-import "./SafeProxy.sol";
+import {SafeProxy} from "./SafeProxy.sol";
 
 /**
  * @title IProxyCreationCallback

--- a/contracts/proxies/SafeProxy.sol
+++ b/contracts/proxies/SafeProxy.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
+/* solhint-disable one-contract-per-file */
 pragma solidity >=0.7.0 <0.9.0;
 
 /**

--- a/contracts/proxies/SafeProxyFactory.sol
+++ b/contracts/proxies/SafeProxyFactory.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import "./SafeProxy.sol";
-import "./IProxyCreationCallback.sol";
+import {SafeProxy} from "./SafeProxy.sol";
+import {IProxyCreationCallback} from "./IProxyCreationCallback.sol";
 
 /**
  * @title Proxy Factory - Allows to create a new proxy contract and execute a message call to the new proxy within one transaction.
@@ -27,21 +27,23 @@ contract SafeProxyFactory {
         require(isContract(_singleton), "Singleton contract not deployed");
 
         bytes memory deploymentData = abi.encodePacked(type(SafeProxy).creationCode, uint256(uint160(_singleton)));
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             proxy := create2(0x0, add(0x20, deploymentData), mload(deploymentData), salt)
         }
+        /* solhint-enable no-inline-assembly */
         require(address(proxy) != address(0), "Create2 call failed");
 
         if (initializer.length > 0) {
-            // solhint-disable-next-line no-inline-assembly
+            /* solhint-disable no-inline-assembly */
             /// @solidity memory-safe-assembly
             assembly {
                 if eq(call(gas(), proxy, 0, add(initializer, 0x20), mload(initializer), 0, 0), 0) {
                     revert(0, 0)
                 }
             }
+            /* solhint-enable no-inline-assembly */
         }
     }
 
@@ -105,11 +107,12 @@ contract SafeProxyFactory {
      */
     function isContract(address account) internal view returns (bool) {
         uint256 size;
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             size := extcodesize(account)
         }
+        /* solhint-enable no-inline-assembly */
         return size > 0;
     }
 
@@ -119,11 +122,12 @@ contract SafeProxyFactory {
      */
     function getChainId() public view returns (uint256) {
         uint256 id;
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             id := chainid()
         }
+        /* solhint-enable no-inline-assembly */
         return id;
     }
 }

--- a/contracts/test/ERC1155Token.sol
+++ b/contracts/test/ERC1155Token.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import "../interfaces/ERC1155TokenReceiver.sol";
-import "../external/SafeMath.sol";
+import {ERC1155TokenReceiver} from "../interfaces/ERC1155TokenReceiver.sol";
+import {SafeMath} from "../external/SafeMath.sol";
 
 /**
  * @title ERC1155Token - A test ERC1155 token contract
@@ -74,11 +74,12 @@ contract ERC1155Token {
      */
     function isContract(address account) internal view returns (bool) {
         uint256 size;
-        // solhint-disable-next-line no-inline-assembly
+        /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {
             size := extcodesize(account)
         }
+        /* solhint-enable no-inline-assembly */
         return size > 0;
     }
 

--- a/contracts/test/ERC20Token.sol
+++ b/contracts/test/ERC20Token.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.6.0 <0.8.0;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 /**
  * @title ERC20Token

--- a/contracts/test/Test4337ModuleAndHandler.sol
+++ b/contracts/test/Test4337ModuleAndHandler.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
+/* solhint-disable one-contract-per-file */
 pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 
@@ -27,14 +28,14 @@ interface ISafe {
 ///      The module does not perform ANY validation, it just executes validateUserOp and execTransaction
 ///      to perform the opcode level compliance by the bundler.
 contract Test4337ModuleAndHandler {
-    address public immutable myAddress;
-    address public immutable entryPoint;
+    address public immutable MY_ADDRESS;
+    address public immutable ENTRYPOINT;
 
     address internal constant SENTINEL_MODULES = address(0x1);
 
     constructor(address entryPointAddress) {
-        entryPoint = entryPointAddress;
-        myAddress = address(this);
+        ENTRYPOINT = entryPointAddress;
+        MY_ADDRESS = address(this);
     }
 
     function validateUserOp(UserOperation calldata userOp, bytes32, uint256 missingAccountFunds) external returns (uint256 validationData) {
@@ -42,7 +43,7 @@ contract Test4337ModuleAndHandler {
         ISafe senderSafe = ISafe(safeAddress);
 
         if (missingAccountFunds != 0) {
-            senderSafe.execTransactionFromModule(entryPoint, missingAccountFunds, "", 0);
+            senderSafe.execTransactionFromModule(ENTRYPOINT, missingAccountFunds, "", 0);
         }
 
         return 0;
@@ -55,6 +56,6 @@ contract Test4337ModuleAndHandler {
     }
 
     function enableMyself() public {
-        ISafe(address(this)).enableModule(myAddress);
+        ISafe(address(this)).enableModule(MY_ADDRESS);
     }
 }

--- a/contracts/test/TestHandler.sol
+++ b/contracts/test/TestHandler.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import "../handler/HandlerContext.sol";
+import {HandlerContext} from "../handler/HandlerContext.sol";
 
 /**
  * @title TestHandler - A test FallbackHandler contract

--- a/contracts/test/TestImports.sol
+++ b/contracts/test/TestImports.sol
@@ -3,4 +3,5 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 // Import the contract so hardhat compiles it, and we have the ABI available
+// solhint-disable-next-line no-unused-import
 import {MockContract} from "@safe-global/mock-contract/contracts/MockContract.sol";

--- a/test/guards/DelegateCallTransactionGuard.spec.ts
+++ b/test/guards/DelegateCallTransactionGuard.spec.ts
@@ -120,7 +120,7 @@ describe("DelegateCallTransactionGuard", () => {
             const guardAddress = await guard.getAddress();
             await executeContractCallWithSigners(safe, safe, "setGuard", [guardAddress], [user1]);
 
-            expect(await guard.allowedTarget()).to.be.eq(AddressOne);
+            expect(await guard.ALLOWED_TARGET()).to.be.eq(AddressOne);
             const allowedTarget = safe.attach(AddressOne);
             await expect(executeContractCallWithSigners(safe, safe, "setFallbackHandler", [AddressZero], [user1], true)).to.be.revertedWith(
                 "This call is restricted",


### PR DESCRIPTION
This PR:
- Fixes solidity lint errors from new rules by the updated linter in #641 
- Mostly, the fixed errors are either `no-inline-assembly` or `no-global-import`. I also turned off the rule that forced only one contract per file, including interfaces, which doesn't make much sense to me