### PR TITLE
Feature: Enhance 1.4.1 contract checks for support proxy contract

### DIFF
--- a/contracts/libraries/Safe130To141Migration.sol
+++ b/contracts/libraries/Safe130To141Migration.sol
@@ -12,12 +12,11 @@ interface ISafe {
  * @title Migration Contract for Safe Upgrade
  * @notice This contract facilitates the migration of a Safe contract from version 1.3.0 to 1.4.1.
  *         The older versions should use built-in upgrade methods.
- * @dev IMPORTANT: The migration will only work with proxies that store the implementation address in the storage slot 0.
+ * @dev IMPORTANT: The library is intended to be used with the Safe standard proxy that stores the singleton address
+ *      at the storage slot 0. Use at your own risk with custom proxy implementations. The library will block calls
+ *      if the address stored at the storage slot 0 is not a contract. The check is implemented in the `checkCurrentSingleton` function.
  */
 contract Safe130To141Migration is SafeStorage {
-    // Address of this contract
-    address public immutable MIGRATION_SINGLETON;
-
     // Address of Safe contract version 1.4.1 Singleton
     address public constant SAFE_141_SINGLETON = address(0x41675C099F32341bf84BFc5382aF534df5C7461a);
 
@@ -32,11 +31,25 @@ contract Safe130To141Migration is SafeStorage {
      * @dev Initializes the migrationSingleton with the contract's own address.
      */
     constructor() {
-        MIGRATION_SINGLETON = address(this);
-
         require(isContract(SAFE_141_SINGLETON), "Safe 1.4.1 Singleton is not deployed");
         require(isContract(SAFE_141_SINGLETON_L2), "Safe 1.4.1 Singleton (L2) is not deployed");
         require(isContract(SAFE_141_FALLBACK_HANDLER), "Safe 1.4.1 Fallback Handler is not deployed");
+    }
+
+    /**
+     * @dev Checks whether the current singleton address is a contract.
+     *      The canonical Safe proxy stores the singleton address at the storage slot 0.
+     *      This migration contract doesn't define it's own storage, so the fact that the storage slot 0 is defined
+     *      and is a contract ensures that the contract was called with a DELEGATECALL.
+     */
+    function checkCurrentSingleton() internal view {
+        require(isContract(singleton), "Unsupported proxy contract");
+    }
+
+    /// @dev Modifier that checks whether the current singleton address is a contract.
+    modifier validSingletonOnly() {
+        checkCurrentSingleton();
+        _;
     }
 
     /**
@@ -49,9 +62,7 @@ contract Safe130To141Migration is SafeStorage {
      * @notice Migrate to Safe 1.4.1 Singleton (L1) at `SAFE_141_SINGLETON`
      * @dev This function should only be called via a delegatecall to perform the upgrade.
      */
-    function migrate() public {
-        require(address(this) != MIGRATION_SINGLETON, "Migration should only be called via delegatecall");
-
+    function migrate() public validSingletonOnly {
         singleton = SAFE_141_SINGLETON;
 
         emit ChangedMasterCopy(singleton);
@@ -71,9 +82,7 @@ contract Safe130To141Migration is SafeStorage {
      * @notice Migrate to Safe 1.4.1 Singleton (L2) at `SAFE_141_SINGLETON_L2`
      * @dev This function should only be called via a delegatecall to perform the upgrade.
      */
-    function migrateL2() public {
-        require(address(this) != MIGRATION_SINGLETON, "Migration should only be called via delegatecall");
-
+    function migrateL2() public validSingletonOnly {
         singleton = SAFE_141_SINGLETON_L2;
 
         emit ChangedMasterCopy(singleton);


### PR DESCRIPTION
This PR:
- Closes https://github.com/safe-global/safe-contracts/issues/672 by implementing the same checks as in the 1.5.0 contract that validates that the address stored at the storage slot 0 is a contract (conventional storage proxy)