### PR TITLE
Explicitly Request Required PR Permission for CLA Bot

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,6 +5,12 @@ on:
   pull_request_target:
     types: [ opened, closed, synchronize ]
 
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Change the CLA bot to explicitly request the required permissions. This is done in accordance to the CLA bot [documentation](https://github.com/contributor-assistant/github-action#1-add-the-following-workflow-file-to-your-repository-in-this-pathgithubworkflowsclayml):

> ```
> # explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
> permissions:
>   actions: write
>   contents: write
>   pull-requests: write
>   statuses: write
> ```