### PR TITLE
Feature: Remove unused bytes from core contract's `checkSignatures` method 

### DIFF
--- a/certora/specs/NativeTokenRefund.spec
+++ b/certora/specs/NativeTokenRefund.spec
@@ -1,7 +1,7 @@
 // This spec is a separate file because we summarize checkSignatures here
 
 methods {
-    function checkSignatures(bytes32, bytes memory, bytes memory) internal => NONDET;
+    function checkSignatures(bytes32, bytes memory) internal => NONDET;
 
     function getNativeTokenBalanceFor(address) external returns (uint256) envfree;
     function getSafeGuard() external returns (address) envfree;

--- a/certora/specs/Safe.spec
+++ b/certora/specs/Safe.spec
@@ -17,7 +17,7 @@ methods {
     function execTransactionFromModule(address,uint256,bytes,Enum.Operation) external returns (bool);
     function execTransaction(address,uint256,bytes,Enum.Operation,uint256,uint256,uint256,address,address,bytes) external returns (bool);
 
-    function checkSignatures(bytes32, bytes memory, bytes memory) internal => NONDET;
+    function checkSignatures(bytes32, bytes memory) internal => NONDET;
 }
 
 definition reachableOnly(method f) returns bool =

--- a/certora/specs/Signatures.spec
+++ b/certora/specs/Signatures.spec
@@ -27,7 +27,7 @@ methods {
     // ) external returns (bytes32) => transactionHashGhost(to, value, callKeccak256(data), operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, _nonce) ;
 
     // optional
-    function checkSignatures(bytes32,bytes,bytes) external;
+    function checkSignatures(bytes32,bytes) external;
     function execTransaction(address,uint256,bytes,Enum.Operation,uint256,uint256,uint256,address,address,bytes) external returns (bool);
 }
 
@@ -58,7 +58,6 @@ function signatureSplitGhost(bytes signatures, uint256 pos) returns (uint8,bytes
 // both signatures concatenated
 rule checkSignatures() {
     bytes32 dataHash;
-    bytes data;
     address executor;
     env e;
     bytes signaturesAB;
@@ -77,18 +76,17 @@ rule checkSignatures() {
     require vA == vAB1 && rA == rAB1 && sA == sAB1;
     require vB == vAB2 && rB == rAB2 && sB == sAB2;
     require vA != 0 && vB != 0;
-    require data.length == 0;
     require !isOwner(currentContract);
     require getThreshold() == 2;
     require getCurrentOwner(dataHash, vA, rA, sA) < getCurrentOwner(dataHash, vB, rB, sB);
     require executor == e.msg.sender;
 
-    checkNSignatures@withrevert(e, executor, dataHash, data, signaturesA, 1);
+    checkNSignatures@withrevert(e, executor, dataHash, signaturesA, 1);
     bool successA = !lastReverted;
-    checkNSignatures@withrevert(e, executor, dataHash, data, signaturesB, 1);
+    checkNSignatures@withrevert(e, executor, dataHash, signaturesB, 1);
     bool successB = !lastReverted;
 
-    checkSignatures@withrevert(e, dataHash, data, signaturesAB);
+    checkSignatures@withrevert(e, dataHash, signaturesAB);
     bool successAB = !lastReverted;
 
     assert (successA && successB) <=> successAB, "checkNSignatures called twice separately must be equivalent to checkSignatures";

--- a/test/core/Safe.Signatures.spec.ts
+++ b/test/core/Safe.Signatures.spec.ts
@@ -321,7 +321,7 @@ describe("Safe", () => {
                 "0000000000000000000000000000000000000000000000000000000000000020" +
                 "00" + // r, s, v
                 "0000000000000000000000000000000000000000000000000000000000000000"; // Some data to read
-            await expect(safe.checkSignatures(txHash, "0x", signatures)).to.be.revertedWith("GS021");
+            await expect(safe.checkSignatures(txHash, signatures)).to.be.revertedWith("GS021");
         });
 
         it("should fail if signatures data is not present", async () => {
@@ -331,7 +331,6 @@ describe("Safe", () => {
             } = await setupTests();
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
-            const txHashData = preimageSafeTransactionHash(safeAddress, tx, await chainId());
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
 
             const signatures =
@@ -341,7 +340,7 @@ describe("Safe", () => {
                 "0000000000000000000000000000000000000000000000000000000000000041" +
                 "00"; // r, s, v
 
-            await expect(safe.checkSignatures(txHash, txHashData, signatures)).to.be.revertedWith("GS022");
+            await expect(safe.checkSignatures(txHash, signatures)).to.be.revertedWith("GS022");
         });
 
         it("should fail if signatures data is too short", async () => {
@@ -351,7 +350,6 @@ describe("Safe", () => {
             } = await setupTests();
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
-            const txHashData = preimageSafeTransactionHash(safeAddress, tx, await chainId());
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
 
             const signatures =
@@ -362,7 +360,7 @@ describe("Safe", () => {
                 "00" + // r, s, v
                 "0000000000000000000000000000000000000000000000000000000000000020"; // length
 
-            await expect(safe.checkSignatures(txHash, txHashData, signatures)).to.be.revertedWith("GS023");
+            await expect(safe.checkSignatures(txHash, signatures)).to.be.revertedWith("GS023");
         });
 
         it("should not be able to use different chainId for signing", async () => {
@@ -372,10 +370,9 @@ describe("Safe", () => {
             const safe = await getSafeWithOwners([user1.address]);
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
-            const txHashData = preimageSafeTransactionHash(safeAddress, tx, await chainId());
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
             const signatures = buildSignatureBytes([await safeSignTypedData(user1, safeAddress, tx, 1)]);
-            await expect(safe.checkSignatures(txHash, txHashData, signatures)).to.be.revertedWith("GS026");
+            await expect(safe.checkSignatures(txHash, signatures)).to.be.revertedWith("GS026");
         });
 
         it("if not msg.sender on-chain approval is required", async () => {
@@ -386,10 +383,9 @@ describe("Safe", () => {
             const safeAddress = await safe.getAddress();
             const user2Safe = safe.connect(user2);
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
-            const txHashData = preimageSafeTransactionHash(safeAddress, tx, await chainId());
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
             const signatures = buildSignatureBytes([await safeApproveHash(user1, safe, tx, true)]);
-            await expect(user2Safe.checkSignatures(txHash, txHashData, signatures)).to.be.revertedWith("GS025");
+            await expect(user2Safe.checkSignatures(txHash, signatures)).to.be.revertedWith("GS025");
         });
 
         it("should revert if threshold is not set", async () => {
@@ -397,9 +393,8 @@ describe("Safe", () => {
             const safe = await getSafeTemplate();
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
-            const txHashData = preimageSafeTransactionHash(safeAddress, tx, await chainId());
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
-            await expect(safe.checkSignatures(txHash, txHashData, "0x")).to.be.revertedWith("GS001");
+            await expect(safe.checkSignatures(txHash, "0x")).to.be.revertedWith("GS001");
         });
 
         it("should revert if not the required amount of signature data is provided", async () => {
@@ -409,9 +404,8 @@ describe("Safe", () => {
             const safe = await getSafeWithOwners([user1.address, user2.address, user3.address]);
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
-            const txHashData = preimageSafeTransactionHash(safeAddress, tx, await chainId());
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
-            await expect(safe.checkSignatures(txHash, txHashData, "0x")).to.be.revertedWith("GS020");
+            await expect(safe.checkSignatures(txHash, "0x")).to.be.revertedWith("GS020");
         });
 
         it("should not be able to use different signature type of same owner", async () => {
@@ -421,14 +415,13 @@ describe("Safe", () => {
             const safe = await getSafeWithOwners([user1.address, user2.address, user3.address]);
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
-            const txHashData = preimageSafeTransactionHash(safeAddress, tx, await chainId());
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
             const signatures = buildSignatureBytes([
                 await safeApproveHash(user1, safe, tx),
                 await safeSignTypedData(user1, safeAddress, tx),
                 await safeSignTypedData(user3, safeAddress, tx),
             ]);
-            await expect(safe.checkSignatures(txHash, txHashData, signatures)).to.be.revertedWith("GS026");
+            await expect(safe.checkSignatures(txHash, signatures)).to.be.revertedWith("GS026");
         });
 
         it("should be able to mix all signature types", async () => {
@@ -456,7 +449,176 @@ describe("Safe", () => {
                 signerSafeSig,
             ]);
 
-            await safe.checkSignatures(txHash, "0x", signatures);
+            await safe.checkSignatures(txHash, signatures);
+        });
+    });
+
+    describe("checkSignatures (legacy)", () => {
+        it("should fail if signature points into static part", async () => {
+            const {
+                safe,
+                safeWithCompatFbHandlerIface,
+                signers: [user1],
+            } = await setupTests();
+            const safeAddress = await safe.getAddress();
+            const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
+
+            const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
+            const signatures =
+                "0x" +
+                "000000000000000000000000" +
+                user1.address.slice(2) +
+                "0000000000000000000000000000000000000000000000000000000000000020" +
+                "00" + // r, s, v
+                "0000000000000000000000000000000000000000000000000000000000000000"; // Some data to read
+            await expect(safeWithCompatFbHandlerIface.checkSignatures(txHash, "0x", signatures)).to.be.revertedWith("GS021");
+        });
+
+        it("should fail if signatures data is not present", async () => {
+            const {
+                safe,
+                safeWithCompatFbHandlerIface,
+                signers: [user1],
+            } = await setupTests();
+            const safeAddress = await safe.getAddress();
+            const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
+            const txHashData = preimageSafeTransactionHash(safeAddress, tx, await chainId());
+            const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
+
+            const signatures =
+                "0x" +
+                "000000000000000000000000" +
+                user1.address.slice(2) +
+                "0000000000000000000000000000000000000000000000000000000000000041" +
+                "00"; // r, s, v
+
+            await expect(safeWithCompatFbHandlerIface.checkSignatures(txHash, txHashData, signatures)).to.be.revertedWith("GS022");
+        });
+
+        it("should fail if signatures data is too short", async () => {
+            const {
+                safe,
+                signers: [user1],
+                safeWithCompatFbHandlerIface,
+            } = await setupTests();
+            const safeAddress = await safe.getAddress();
+            const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
+            const txHashData = preimageSafeTransactionHash(safeAddress, tx, await chainId());
+            const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
+
+            const signatures =
+                "0x" +
+                "000000000000000000000000" +
+                user1.address.slice(2) +
+                "0000000000000000000000000000000000000000000000000000000000000041" +
+                "00" + // r, s, v
+                "0000000000000000000000000000000000000000000000000000000000000020"; // length
+
+            await expect(safeWithCompatFbHandlerIface.checkSignatures(txHash, txHashData, signatures)).to.be.revertedWith("GS023");
+        });
+
+        it("should not be able to use different chainId for signing", async () => {
+            const {
+                signers: [user1],
+                compatFallbackHandler,
+            } = await setupTests();
+            const safe = await getSafeWithOwners([user1.address], 1, await compatFallbackHandler.getAddress());
+            const safeAddress = await safe.getAddress();
+            const safeWithCompatFbHandlerIface = await getCompatFallbackHandler(safeAddress);
+            const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
+            const txHashData = preimageSafeTransactionHash(safeAddress, tx, await chainId());
+            const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
+            const signatures = buildSignatureBytes([await safeSignTypedData(user1, safeAddress, tx, 1)]);
+            await expect(safeWithCompatFbHandlerIface.checkSignatures(txHash, txHashData, signatures)).to.be.revertedWith("GS026");
+        });
+
+        it("if not msg.sender on-chain approval is required", async () => {
+            const {
+                safe,
+                safeWithCompatFbHandlerIface,
+                signers: [user1, user2],
+            } = await setupTests();
+            const safeAddress = await safe.getAddress();
+            const user2Safe = safeWithCompatFbHandlerIface.connect(user2);
+            const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
+            const txHashData = preimageSafeTransactionHash(safeAddress, tx, await chainId());
+            const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
+            const signatures = buildSignatureBytes([await safeApproveHash(user1, safe, tx, true)]);
+            await expect(user2Safe.checkSignatures(txHash, txHashData, signatures)).to.be.revertedWith("GS025");
+        });
+
+        it("should revert if not the required amount of signature data is provided", async () => {
+            const {
+                compatFallbackHandler,
+                signers: [user1, user2, user3],
+            } = await setupTests();
+            const safe = await getSafeWithOwners(
+                [user1.address, user2.address, user3.address],
+                3,
+                await compatFallbackHandler.getAddress(),
+            );
+            const safeAddress = await safe.getAddress();
+            const safeWithCompatFbHandlerIface = await getCompatFallbackHandler(safeAddress);
+            const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
+            const txHashData = preimageSafeTransactionHash(safeAddress, tx, await chainId());
+            const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
+            await expect(safeWithCompatFbHandlerIface.checkSignatures(txHash, txHashData, "0x")).to.be.revertedWith("GS020");
+        });
+
+        it("should not be able to use different signature type of same owner", async () => {
+            const {
+                compatFallbackHandler,
+                signers: [user1, user2, user3],
+            } = await setupTests();
+            const safe = await getSafeWithOwners(
+                [user1.address, user2.address, user3.address],
+                3,
+                await compatFallbackHandler.getAddress(),
+            );
+            const safeAddress = await safe.getAddress();
+            const safeWithCompatFbHandlerIface = await getCompatFallbackHandler(safeAddress);
+            const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
+            const txHashData = preimageSafeTransactionHash(safeAddress, tx, await chainId());
+            const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
+            const signatures = buildSignatureBytes([
+                await safeApproveHash(user1, safe, tx),
+                await safeSignTypedData(user1, safeAddress, tx),
+                await safeSignTypedData(user3, safeAddress, tx),
+            ]);
+            await expect(safeWithCompatFbHandlerIface.checkSignatures(txHash, txHashData, signatures)).to.be.revertedWith("GS026");
+        });
+
+        it("should be able to mix all signature types", async () => {
+            const {
+                compatFallbackHandler,
+                signers: [user1, user2, user3, user4, user5],
+            } = await setupTests();
+            const compatFallbackHandlerAddress = await compatFallbackHandler.getAddress();
+            const signerSafe = await getSafeWithOwners([user5.address], 1, compatFallbackHandlerAddress);
+            const signerSafeAddress = await signerSafe.getAddress();
+            const safe = await getSafeWithOwners(
+                [user1.address, user2.address, user3.address, user4.address, signerSafeAddress],
+                5,
+                compatFallbackHandlerAddress,
+            );
+            const safeAddress = await safe.getAddress();
+            const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
+            const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
+            const safeWithCompatFbHandlerIface = await getCompatFallbackHandler(safeAddress);
+
+            const safeMessageHash = calculateSafeMessageHash(signerSafeAddress, txHash, await chainId());
+            const signerSafeOwnerSignature = await signHash(user5, safeMessageHash);
+            const signerSafeSig = buildContractSignature(signerSafeAddress, signerSafeOwnerSignature.data);
+
+            const signatures = buildSignatureBytes([
+                await safeApproveHash(user1, safe, tx, true),
+                await safeApproveHash(user4, safe, tx),
+                await safeSignTypedData(user2, safeAddress, tx),
+                await safeSignTypedData(user3, safeAddress, tx),
+                signerSafeSig,
+            ]);
+
+            await safeWithCompatFbHandlerIface.checkSignatures(txHash, "0x", signatures);
         });
     });
 
@@ -477,7 +639,7 @@ describe("Safe", () => {
                 "0000000000000000000000000000000000000000000000000000000000000020" +
                 "00" + // r, s, v
                 "0000000000000000000000000000000000000000000000000000000000000000"; // Some data to read
-            await expect(safe.checkNSignatures(user1.address, txHash, "0x", signatures, 1)).to.be.revertedWith("GS021");
+            await expect(safe.checkNSignatures(user1.address, txHash, signatures, 1)).to.be.revertedWith("GS021");
         });
 
         it("should fail if signatures data is not present", async () => {
@@ -497,7 +659,7 @@ describe("Safe", () => {
                 "0000000000000000000000000000000000000000000000000000000000000041" +
                 "00"; // r, s, v
 
-            await expect(safe.checkNSignatures(user1.address, txHash, "0x", signatures, 1)).to.be.revertedWith("GS022");
+            await expect(safe.checkNSignatures(user1.address, txHash, signatures, 1)).to.be.revertedWith("GS022");
         });
 
         it("should fail if signatures data is too short", async () => {
@@ -518,7 +680,7 @@ describe("Safe", () => {
                 "00" + // r, s, v
                 "0000000000000000000000000000000000000000000000000000000000000020"; // length
 
-            await expect(safe.checkNSignatures(user1.address, txHash, "0x", signatures, 1)).to.be.revertedWith("GS023");
+            await expect(safe.checkNSignatures(user1.address, txHash, signatures, 1)).to.be.revertedWith("GS023");
         });
 
         it("should not be able to use different chainId for signing", async () => {
@@ -530,7 +692,7 @@ describe("Safe", () => {
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
             const signatures = buildSignatureBytes([await safeSignTypedData(user1, safeAddress, tx, 1)]);
-            await expect(safe.checkNSignatures(user1.address, txHash, "0x", signatures, 1)).to.be.revertedWith("GS026");
+            await expect(safe.checkNSignatures(user1.address, txHash, signatures, 1)).to.be.revertedWith("GS026");
         });
 
         it("if not msg.sender on-chain approval is required", async () => {
@@ -543,7 +705,7 @@ describe("Safe", () => {
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
             const signatures = buildSignatureBytes([await safeApproveHash(user1, safe, tx, true)]);
-            await expect(user2Safe.checkNSignatures(AddressZero, txHash, "0x", signatures, 1)).to.be.revertedWith("GS025");
+            await expect(user2Safe.checkNSignatures(AddressZero, txHash, signatures, 1)).to.be.revertedWith("GS025");
         });
 
         it("should revert if not the required amount of signature data is provided", async () => {
@@ -554,7 +716,7 @@ describe("Safe", () => {
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
-            await expect(safe.checkNSignatures(AddressZero, txHash, "0x", "0x", 1)).to.be.revertedWith("GS020");
+            await expect(safe.checkNSignatures(AddressZero, txHash, "0x", 1)).to.be.revertedWith("GS020");
         });
 
         it("should not be able to use different signature type of same owner", async () => {
@@ -570,7 +732,7 @@ describe("Safe", () => {
                 await safeSignTypedData(user1, safeAddress, tx),
                 await safeSignTypedData(user3, safeAddress, tx),
             ]);
-            await expect(safe.checkNSignatures(AddressZero, txHash, "0x", signatures, 3)).to.be.revertedWith("GS026");
+            await expect(safe.checkNSignatures(AddressZero, txHash, signatures, 3)).to.be.revertedWith("GS026");
         });
 
         it("should be able to mix all signature types", async () => {
@@ -598,7 +760,7 @@ describe("Safe", () => {
                 signerSafeSig,
             ]);
 
-            await safe.checkNSignatures(user1.address, txHash, "0x", signatures, 5);
+            await safe.checkNSignatures(user1.address, txHash, signatures, 5);
         });
 
         it("should be able to require no signatures", async () => {
@@ -607,7 +769,7 @@ describe("Safe", () => {
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
 
-            await safe.checkNSignatures(AddressZero, txHash, "0x", "0x", 0);
+            await safe.checkNSignatures(AddressZero, txHash, "0x", 0);
         });
 
         it("should be able to require less signatures than the threshold", async () => {
@@ -620,7 +782,7 @@ describe("Safe", () => {
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
             const signatures = buildSignatureBytes([await safeSignTypedData(user3, safeAddress, tx)]);
 
-            await safe.checkNSignatures(AddressZero, txHash, "0x", signatures, 1);
+            await safe.checkNSignatures(AddressZero, txHash, signatures, 1);
         });
 
         it("should be able to require more signatures than the threshold", async () => {
@@ -638,9 +800,9 @@ describe("Safe", () => {
             ]);
 
             // Should fail as only 3 signatures are provided
-            await expect(safe.checkNSignatures(user1.address, txHash, "0x", signatures, 4)).to.be.revertedWith("GS020");
+            await expect(safe.checkNSignatures(user1.address, txHash, signatures, 4)).to.be.revertedWith("GS020");
 
-            await safe.checkNSignatures(user1.address, txHash, "0x", signatures, 3);
+            await safe.checkNSignatures(user1.address, txHash, signatures, 3);
         });
 
         it("Should accept an arbitrary msg.sender", async () => {
@@ -656,7 +818,7 @@ describe("Safe", () => {
             const signatures = buildSignatureBytes([await safeApproveHash(user1, safe, tx, true)]);
             const safeConnectUser2 = safe.connect(user2);
 
-            await safeConnectUser2.checkNSignatures(user1.address, txHash, "0x", signatures, 1);
+            await safeConnectUser2.checkNSignatures(user1.address, txHash, signatures, 1);
         });
     });
 


### PR DESCRIPTION
This PR:
- Implements https://github.com/safe-global/safe-contracts/issues/687 by removing the `bytes` parameter from the core contract's and adding the method with the old signature to the `CompatibilityFallbackHandler`
- Our [change](https://github.com/safe-global/safe-contracts/pull/589) for the overloaded checkNSignatures method with the executor address came in handy when adding the backwards compatible method because we can grab the original sender's address and forward it to the method