### PR TITLE
Feature: Update `onlyOwnersGuard` to use `O(1)` lookup, fix an incorrect test

### DIFF
--- a/contracts/examples/guards/OnlyOwnersGuard.sol
+++ b/contracts/examples/guards/OnlyOwnersGuard.sol
@@ -6,7 +6,7 @@ import {Enum} from "../../common/Enum.sol";
 import {BaseGuard} from "../../base/GuardManager.sol";
 
 interface ISafe {
-    function getOwners() external view returns (address[] memory);
+    function isOwner(address owner) external view returns (bool);
 }
 
 /**
@@ -14,8 +14,6 @@ interface ISafe {
  * @author Richard Meissner - @rmeissner
  */
 contract OnlyOwnersGuard is BaseGuard {
-    ISafe public safe;
-
     constructor() {}
 
     // solhint-disable-next-line payable-fallback
@@ -43,16 +41,7 @@ contract OnlyOwnersGuard is BaseGuard {
         bytes memory,
         address msgSender
     ) external view override {
-        // Only owners can exec
-        address[] memory owners = ISafe(msg.sender).getOwners();
-        for (uint256 i = 0; i < owners.length; i++) {
-            if (owners[i] == msgSender) {
-                return;
-            }
-        }
-
-        // msg sender is not an owner
-        revert("msg sender is not allowed to exec");
+        require(ISafe(msg.sender).isOwner(msgSender), "msg sender is not allowed to exec");
     }
 
     function checkAfterExecution(bytes32, bool) external view override {}


### PR DESCRIPTION
This PR:
- Update the example `onlyOwnersGuard` to use `O(1)` owner lookup instead of `O(n)`
- The test for the guard's "happy" path was incorrect because it signed a transaction with user2, which wasn't an owner and the `safe` instance was still connected to the owner's signer. The transaction failed with `GS026`, Safe's built-in error for an incorrect owner. The guard actually didn't stop the transaction 