### PR TITLE
Add test for forwarding calls to self for `MultiSend` and `MultiSendCallOnly`

### DIFF
--- a/test/libraries/MultiSendCallOnly.spec.ts
+++ b/test/libraries/MultiSendCallOnly.spec.ts
@@ -1,7 +1,14 @@
 import { expect } from "chai";
 import hre, { deployments, ethers } from "hardhat";
 import { deployContract, getMock, getMultiSendCallOnly, getSafeWithOwners, getDelegateCaller } from "../utils/setup";
-import { buildContractCall, buildSafeTransaction, executeTx, MetaTransaction, safeApproveHash } from "../../src/utils/execution";
+import {
+    buildContractCall,
+    buildSafeTransaction,
+    executeTx,
+    executeTxWithSigners,
+    MetaTransaction,
+    safeApproveHash,
+} from "../../src/utils/execution";
 import { buildMultiSendSafeTx } from "../../src/utils/multisend";
 
 describe("MultiSendCallOnly", () => {
@@ -210,6 +217,40 @@ describe("MultiSendCallOnly", () => {
             const { data } = await buildMultiSendSafeTx(multiSend, txs, 0);
 
             await expect(delegateCaller.makeDelegatecall.staticCall(multisendAddress, data)).to.be.revertedWith(errorMessage);
+        });
+
+        it("forwards the call to self when to is zero address", async () => {
+            const {
+                safe,
+                multiSend,
+                signers: [user1],
+            } = await setupTests();
+            const randomAddress1 = ethers.hexlify(ethers.randomBytes(20));
+            const randomAddress2 = ethers.hexlify(ethers.randomBytes(20));
+
+            await expect(await safe.isOwner(randomAddress1)).to.be.false;
+            await expect(await safe.isOwner(randomAddress2)).to.be.false;
+
+            const txs: MetaTransaction[] = [
+                {
+                    to: ethers.ZeroAddress,
+                    value: 0,
+                    data: safe.interface.encodeFunctionData("addOwnerWithThreshold", [randomAddress1, 1]),
+                    operation: 0,
+                },
+                {
+                    to: ethers.ZeroAddress,
+                    value: 0,
+                    data: safe.interface.encodeFunctionData("addOwnerWithThreshold", [randomAddress2, 1]),
+                    operation: 0,
+                },
+            ];
+            const safeTx = await buildMultiSendSafeTx(multiSend, txs, await safe.nonce());
+
+            await executeTxWithSigners(safe, safeTx, [user1]);
+
+            await expect(await safe.isOwner(randomAddress1)).to.be.true;
+            await expect(await safe.isOwner(randomAddress2)).to.be.true;
         });
     });
 });


### PR DESCRIPTION
This PR:
- Is an iteration of https://github.com/safe-global/safe-contracts/pull/695
- Adds two straightforward tests that enable owners on a Safe while specifying the `to` address as 0