### PR TITLE
Uncomment the execTransaction rule

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -29,7 +29,7 @@ jobs:
               with: { java-version: "17", java-package: jre, distribution: semeru }
 
             - name: Install certora cli
-              run: pip install -Iv certora-cli==4.13.1
+              run: pip install -Iv certora-cli
 
             - name: Install solc
               run: |

--- a/certora/applyHarness.patch
+++ b/certora/applyHarness.patch
@@ -1,6 +1,6 @@
 diff -druN Safe.sol Safe.sol
---- Safe.sol	2023-09-29 15:38:28
-+++ Safe.sol	2023-09-29 15:40:17
+--- Safe.sol	2023-11-10 09:50:31
++++ Safe.sol	2023-11-20 11:06:39
 @@ -76,7 +76,7 @@
           * so we create a Safe with 0 owners and threshold 1.
           * This is an unusable Safe, perfect for the singleton
@@ -31,9 +31,19 @@ diff -druN Safe.sol Safe.sol
          // setupOwners checks if the Threshold is already set, therefore preventing that this method is called twice
          setupOwners(_owners, _threshold);
          if (fallbackHandler != address(0)) internalSetFallbackHandler(fallbackHandler);
+@@ -451,7 +453,8 @@
+         address gasToken,
+         address refundReceiver,
+         uint256 _nonce
+-    ) public view returns (bytes32) {
++    ) internal view returns (bytes32) {
++        // MUNGED: The function was made internal to enable CVL summaries.
+         return keccak256(encodeTransactionData(to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, _nonce));
+     }
+ }
 diff -druN base/Executor.sol base/Executor.sol
---- base/Executor.sol	2023-09-26 16:12:09
-+++ base/Executor.sol	2023-09-26 16:10:42
+--- base/Executor.sol	2023-11-10 09:50:31
++++ base/Executor.sol	2023-11-20 10:28:47
 @@ -26,12 +26,8 @@
          uint256 txGas
      ) internal returns (bool success) {

--- a/certora/harnesses/SafeHarness.sol
+++ b/certora/harnesses/SafeHarness.sol
@@ -56,7 +56,19 @@ contract SafeHarness is Safe {
         return getOwners().length;
     }
 
-    function callKeccak256(bytes memory data) external view returns (bytes32) {
-        return keccak256(data);
+    function getTransactionHashPublic(
+        address to,
+        uint256 value,
+        bytes calldata data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address refundReceiver,
+        uint256 _nonce
+    ) public view returns (bytes32) {
+        // MUNGED: The function was made internal to enable CVL summaries.
+        return getTransactionHash(to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, _nonce);
     }
 }


### PR DESCRIPTION
A follow up on: https://github.com/safe-global/safe-contracts/pull/702

It uncomments the rule the ghost was meant for and adds a public method for the summarized method (summaries only work for internal methods). Removes some unused methods.