### PR TITLE
Fix Typo In Migration Contract Comment

### DIFF
--- a/contracts/libraries/SafeToL2Migration.sol
+++ b/contracts/libraries/SafeToL2Migration.sol
@@ -115,7 +115,7 @@ contract SafeToL2Migration is SafeStorage {
         bytes32 newSingletonVersion = keccak256(abi.encodePacked(ISafe(l2Singleton).VERSION()));
 
         require(oldSingletonVersion == newSingletonVersion, "L2 singleton must match current version singleton");
-        // There's no way to make sure if address is a valid singleton, unless we cofigure the contract for every chain
+        // There's no way to make sure if address is a valid singleton, unless we configure the contract for every chain
         require(
             newSingletonVersion == keccak256(abi.encodePacked("1.3.0")) || newSingletonVersion == keccak256(abi.encodePacked("1.4.1")),
             "Provided singleton version is not supported"


### PR DESCRIPTION
This PR just fixes a small typo in a comment of the `SafeToL2Migration.sol` contract.

[Kudos](https://github.com/safe-global/safe-contracts/commit/482332f4f45859e8faafe8523cb2c5baa2573862#r136779502) to @Aboudjem for pointing it out!