### PR TITLE
Rename repository to safe-smart-account

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: safe-contracts
+name: safe-smart-account
 on: [push, pull_request]
 env:
     NODE_VERSION: 18.17.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This changelog only contains changes starting from version 1.3.0
 
 ## Compiler settings
 
-Solidity compiler: [0.7.6](https://github.com/ethereum/solidity/releases/tag/v0.7.6) (for more info see issue [#251](https://github.com/safe-global/safe-contracts/issues/251))
+Solidity compiler: [0.7.6](https://github.com/ethereum/solidity/releases/tag/v0.7.6) (for more info see issue [#251](https://github.com/safe-global/safe-smart-account/issues/251))
 
 Solidity optimizer: `disabled`
 
@@ -43,34 +43,34 @@ Solidity optimizer: `disabled`
 
 #### Use updated EIP-1271 function signature in the signature validation process
 
-Issue: [#391](https://github.com/safe-global/safe-contracts/issues/391)
+Issue: [#391](https://github.com/safe-global/safe-smart-account/issues/391)
 
 New function signature implemented and legacy function removed from compatibility fallback handler contract.
 
 #### Remove usage of `transfer` and `send`
 
-Issue: [#601](https://github.com/safe-global/safe-contracts/issues/601)
+Issue: [#601](https://github.com/safe-global/safe-smart-account/issues/601)
 
 Calls to `transfer` and `send` were removed to make the contract not depend on any potential gas cost changes. The calls were replaced with `call`, and that should be kept in mind when using the contract and designing extensions due to potential reentrancy vectors.
 
 #### Make assembly blocks memory safe
 
-Issue: [#544](https://github.com/safe-global/safe-contracts/issues/544)
+Issue: [#544](https://github.com/safe-global/safe-smart-account/issues/544)
 
 The contracts couldn't be compiled with the solidity compiler versions 0.8.19+ because of the compiler optimizations that copy stack variables to memory to prevent stack-too-deep errors. In some assembly blocks, the scratch space was used, and that's not
 considered safe, so all the assembly blocks were adjusted to use safe memory allocation.
 
 #### Add `checkModuleTransaction` method to the guard
 
-Issue: [#335](https://github.com/safe-global/safe-contracts/issues/335)
+Issue: [#335](https://github.com/safe-global/safe-smart-account/issues/335)
 
 The `checkModuleTransaction` method was added to the guard to allow checking the module transactions before execution. The method is called before the `checkAfterExecution` method. While migrating, it should be checked if a Safe has an existing guard and if it implements the `checkModuleTransaction` method. If it doesn't, module transactions will be blocked.
 
 #### Add overloaded `checkNSignatures` method
 
 Issues: 
-- [#557](https://github.com/safe-global/safe-contracts/pull/557)
-- [#589](https://github.com/safe-global/safe-contracts/pull/589)
+- [#557](https://github.com/safe-global/safe-smart-account/pull/557)
+- [#589](https://github.com/safe-global/safe-smart-account/pull/589)
 
 Previously pre-approved signatures relying on the `msg.sender` variable couldn't be used in guards or modules without duplicating the logic within the module itself. This is now improved by adding an overloaded `checkNSignatures` method that accepts a `msg.sender` parameter. This allows the module to pass the `msg.sender` variable to the `checkNSignatures` method and use the pre-approved signatures. The old method was moved from the core contract to the `CompatibilityFallbackHandler`.
 
@@ -82,7 +82,7 @@ To fit all of the above changes into the bytecode size limit, the `encodeTransac
 
 ## Compiler settings
 
-Solidity compiler: [0.7.6](https://github.com/ethereum/solidity/releases/tag/v0.7.6) (for more info see issue [#251](https://github.com/safe-global/safe-contracts/issues/251))
+Solidity compiler: [0.7.6](https://github.com/ethereum/solidity/releases/tag/v0.7.6) (for more info see issue [#251](https://github.com/safe-global/safe-smart-account/issues/251))
 
 Solidity optimizer: `disabled`
 
@@ -119,7 +119,7 @@ Solidity optimizer: `disabled`
 
 #### Remove `gasleft()` usage in `setupModules`
 
-Issue: [#568](https://github.com/safe-global/safe-contracts/issues/568)
+Issue: [#568](https://github.com/safe-global/safe-smart-account/issues/568)
 
 `setupModules` made a call to `gasleft()` that is invalid in the ERC-4337 standard. The call was replaced with `type(uint256).max` to forward all the available gas instead.
 
@@ -128,7 +128,7 @@ Issue: [#568](https://github.com/safe-global/safe-contracts/issues/568)
 
 ## Compiler settings
 
-Solidity compiler: [0.7.6](https://github.com/ethereum/solidity/releases/tag/v0.7.6) (for more info see issue [#251](https://github.com/safe-global/safe-contracts/issues/251))
+Solidity compiler: [0.7.6](https://github.com/ethereum/solidity/releases/tag/v0.7.6) (for more info see issue [#251](https://github.com/safe-global/safe-smart-account/issues/251))
 
 Solidity optimizer: `disabled`
 
@@ -169,11 +169,11 @@ Removed the "Gnosis" prefix from all contract names.
 
 ### Core contract
 
-File: [`contracts/SafeL2.sol`](https://github.com/safe-global/safe-contracts/blob/3c3fc80f7f9aef1d39aaae2b53db5f4490051b0d/contracts/SafeL2.sol)
+File: [`contracts/SafeL2.sol`](https://github.com/safe-global/safe-smart-account/blob/3c3fc80f7f9aef1d39aaae2b53db5f4490051b0d/contracts/SafeL2.sol)
 
 #### Remove usage of the `GAS` opcode in module execute flows
 
-Issue: [#459](https://github.com/safe-global/safe-contracts/issues/459)
+Issue: [#459](https://github.com/safe-global/safe-smart-account/issues/459)
 
 The following rule of usage of the `GAS` opcode in the ERC-4337 standard made it impossible to build a module to support ERC4337:
 
@@ -183,31 +183,31 @@ We removed the `GAS` opcode usage in module transactions to forward all the avai
 
 #### Require the `to` address to be a contract in `setupModules`
 
-Issue: [#483](https://github.com/safe-global/safe-contracts/issues/483)
+Issue: [#483](https://github.com/safe-global/safe-smart-account/issues/483)
 
 The `setupModules` method was changed to require the `to` address to be a contract. If the `to` address is not a contract, the transaction will revert with a `GS002` error code.
 
 #### Enforce the `dataHash` is equal to `data` in the signature verification process for contract signatures
 
-Issue: [#497](https://github.com/safe-global/safe-contracts/issues/497)
+Issue: [#497](https://github.com/safe-global/safe-smart-account/issues/497)
 
 To prevent unexpected behaviour, the `dataHash` must now equal a hash of the `data` in the signature verification process for contract signatures. Otherwise, the transaction will revert with a `GS027` error code.
 
 #### Fix `getModulesPaginated` to return a correct `next` pointer
 
-Issue: [#461](https://github.com/safe-global/safe-contracts/issues/461)
+Issue: [#461](https://github.com/safe-global/safe-smart-account/issues/461)
 
 The `getModulesPaginated` method was fixed to return a correct `next` pointer. The `next` pointer now equals the last module in the returned array.
 
 #### Check the EIP-165 signature of the Guard before adding
 
-Issue: [#309](https://github.com/safe-global/safe-contracts/issues/309)
+Issue: [#309](https://github.com/safe-global/safe-smart-account/issues/309)
 
 When setting a guard, the core contract will check that the target address supports the Guard interface with an EIP-165 check. If it doesn't, the transaction will revert with the `GS300` error code.
 
 #### Index essential parameters when emitting events
 
-Issue: [#541](https://github.com/safe-global/safe-contracts/issues/541)
+Issue: [#541](https://github.com/safe-global/safe-smart-account/issues/541)
 
 Index essential parameters in the essential events, such as:
 
@@ -219,7 +219,7 @@ Index essential parameters in the essential events, such as:
 
 ### Factory
 
-Umbrella issue: [#462](https://github.com/safe-global/safe-contracts/issues/462)
+Umbrella issue: [#462](https://github.com/safe-global/safe-smart-account/issues/462)
 
 #### Remove the `createProxy` method
 
@@ -246,8 +246,8 @@ The `.runtimeCode` method is not supported by the ZkSync compiler, so we removed
 
 Files:
 
--   [CompatibilityFallbackHandler.sol](https://github.com/safe-global/safe-contracts/blob/3c3fc80f7f9aef1d39aaae2b53db5f4490051b0d/contracts/handler/CompatibilityFallbackHandler.sol)
--   [TokenCallbackHandler](https://github.com/safe-global/safe-contracts/blob/3c3fc80f7f9aef1d39aaae2b53db5f4490051b0d/contracts/handler/TokenCallbackHandler.sol)
+-   [CompatibilityFallbackHandler.sol](https://github.com/safe-global/safe-smart-account/blob/3c3fc80f7f9aef1d39aaae2b53db5f4490051b0d/contracts/handler/CompatibilityFallbackHandler.sol)
+-   [TokenCallbackHandler](https://github.com/safe-global/safe-smart-account/blob/3c3fc80f7f9aef1d39aaae2b53db5f4490051b0d/contracts/handler/TokenCallbackHandler.sol)
 
 #### Rename `DefaultCallbackHandler` to `TokenCallbackHandler`
 
@@ -259,7 +259,7 @@ The `NAME` and `VERSION` constants were removed from the `CompatibilityFallbackH
 
 #### Fix function signature mismatch for `isValidSignature`
 
-Issue: [#440](https://github.com/safe-global/safe-contracts/issues/440)
+Issue: [#440](https://github.com/safe-global/safe-smart-account/issues/440)
 
 Fixed mismatch between the function signature in the `isValidSignature` method and the `ISignatureValidator` interface.
 
@@ -267,11 +267,11 @@ Fixed mismatch between the function signature in the `isValidSignature` method a
 
 #### CreateCall
 
-File: [`contracts/libraries/CreateCall.sol`](https://github.com/safe-global/safe-contracts/blob/3c3fc80f7f9aef1d39aaae2b53db5f4490051b0d/contracts/libraries/CreateCall.sol)
+File: [`contracts/libraries/CreateCall.sol`](https://github.com/safe-global/safe-smart-account/blob/3c3fc80f7f9aef1d39aaae2b53db5f4490051b0d/contracts/libraries/CreateCall.sol)
 
 #### Index the created contract address in the `ContractCreation` event
 
-Issue: [#541](https://github.com/safe-global/safe-contracts/issues/541)
+Issue: [#541](https://github.com/safe-global/safe-smart-account/issues/541)
 
 The deployed contract address in the `ContractCreation` event is now indexed.
 
@@ -279,7 +279,7 @@ The deployed contract address in the `ContractCreation` event is now indexed.
 
 #### Use the Safe Singleton Factory for all deployments
 
-Issue: [#460](https://github.com/safe-global/safe-contracts/issues/460)
+Issue: [#460](https://github.com/safe-global/safe-smart-account/issues/460)
 
 Deployments with the [Safe Singleton Factory](https://github.com/safe-global/safe-singleton-factory) are now the default deployment process to ensure the same addresses on all chains.
 
@@ -287,7 +287,7 @@ Deployments with the [Safe Singleton Factory](https://github.com/safe-global/saf
 
 ## Compiler settings
 
-Solidity compiler: [0.7.6](https://github.com/ethereum/solidity/releases/tag/v0.7.6) (more info see issue [#251](https://github.com/safe-global/safe-contracts/issues/251))
+Solidity compiler: [0.7.6](https://github.com/ethereum/solidity/releases/tag/v0.7.6) (more info see issue [#251](https://github.com/safe-global/safe-smart-account/issues/251))
 
 Solidity optimizer: `disabled`
 
@@ -339,7 +339,7 @@ The following libraries have been marked as production ready.
 
 #### SignMessageLib
 
-File: [`contracts/libraries/SignMessage.sol`](https://github.com/safe-global/safe-contracts/blob/e57df14ea96dc7dabf93f041c7531f2ab6755c76/contracts/libraries/SignMessage.sol)
+File: [`contracts/libraries/SignMessage.sol`](https://github.com/safe-global/safe-smart-account/blob/e57df14ea96dc7dabf93f041c7531f2ab6755c76/contracts/libraries/SignMessage.sol)
 
 Expected behaviour:
 
@@ -348,7 +348,7 @@ The library is meant as a compatibility tool for the removed `signMessage` funct
 #### GnosisSafeStorage
 
 
-File: [`contracts/libraries/GnosisSafeStorage.sol`](https://github.com/safe-global/safe-contracts/blob/e57df14ea96dc7dabf93f041c7531f2ab6755c76/contracts/libraries/GnosisSafeStorage.sol)
+File: [`contracts/libraries/GnosisSafeStorage.sol`](https://github.com/safe-global/safe-smart-account/blob/e57df14ea96dc7dabf93f041c7531f2ab6755c76/contracts/libraries/GnosisSafeStorage.sol)
 
 Expected behaviour:
 
@@ -358,7 +358,7 @@ The contract contains the basic storage layout of the `GnosisSafe.sol` contract 
 
 ## Compiler settings
 
-Solidity compiler: [0.7.6](https://github.com/ethereum/solidity/releases/tag/v0.7.6) (more info see issue [#251](https://github.com/safe-global/safe-contracts/issues/251))
+Solidity compiler: [0.7.6](https://github.com/ethereum/solidity/releases/tag/v0.7.6) (more info see issue [#251](https://github.com/safe-global/safe-smart-account/issues/251))
 
 Solidity optimizer: `disabled`
 
@@ -382,24 +382,24 @@ Solidity optimizer: `disabled`
 ## Changes
 
 ### Core contract
-File: [`contracts/GnosisSafe.sol`](https://github.com/safe-global/safe-contracts/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/GnosisSafe.sol)
+File: [`contracts/GnosisSafe.sol`](https://github.com/safe-global/safe-smart-account/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/GnosisSafe.sol)
 
 #### Add chainId to transaction hash
-Issue: [#170](https://github.com/safe-global/safe-contracts/issues/170)
+Issue: [#170](https://github.com/safe-global/safe-smart-account/issues/170)
 
 Expected behaviour:
 
 The `chainId` has been added to the [EIP-712](https://eips.ethereum.org/EIPS/eip-712) domain. In case of a change of the `chainId` (e.g. hardfork related) the new `chainId` will automatically be used for future signature checks.
 
 #### Add transaction guard
-Issue: [#224](https://github.com/safe-global/safe-contracts/issues/224)
+Issue: [#224](https://github.com/safe-global/safe-smart-account/issues/224)
 
 Expected behaviour:
 
 It is possible to add a transaction guard, which can check all of the parameters that have been sent to `execTransaction` prior to execution. For this check the `checkTransaction` needs to be implemented by the guard. In case that `checkTransaction` reverts, `execTransaction` will also revert. Another check that can be implemented by the guard is `checkAfterExecution`. This check is called at the very end of the execution and allows to perform checks on the final state of the Safe. The parameters passed to that check are the `safeTxHash` and a `success` boolean.
 
 #### Add StorageAccessible support
-Issue: [#201](https://github.com/safe-global/safe-contracts/issues/201)
+Issue: [#201](https://github.com/safe-global/safe-smart-account/issues/201)
 
 Expected behaviour:
 
@@ -414,7 +414,7 @@ Expected behaviour:
 It is not possible anymore to change the singleton address (formerly known as master copy) via a method call. To make the implications of a singleton address change more visible it is required to use a delegatecall with a migration contract. (See example migration in libraries)
 
 #### Make checkSignature public
-Issue: [#248](https://github.com/safe-global/safe-contracts/issues/248)
+Issue: [#248](https://github.com/safe-global/safe-smart-account/issues/248)
 
 Expected behaviour:
 
@@ -423,7 +423,7 @@ Another method that has been added to make the usage from external contracts eas
 Note: The storage allocated by `approveHash` will no longer be zeroed when being used in `checkSignature`. If this is required a delegatecall with a contract that zeroes past approved hashes should be used.
 
 #### Remove authorized from requiredTxGas
-Issue: [#247](https://github.com/safe-global/safe-contracts/issues/247)
+Issue: [#247](https://github.com/safe-global/safe-smart-account/issues/247)
 
 Expected behaviour:
 
@@ -431,7 +431,7 @@ To make it easier to interact with this method (e.g. by providing a wrapper). Th
 Note: This method is superseded by the `StorageAccessible` logic and will be removed in the next major version.
 
 #### Move EIP-1271 logic to fallback handler
-Issue: [#223](https://github.com/safe-global/safe-contracts/issues/223)
+Issue: [#223](https://github.com/safe-global/safe-smart-account/issues/223)
 
 Expected behaviour:
 
@@ -439,7 +439,7 @@ As [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) is still changing the log
 Note: The `checkSignature` method still uses the previous version of [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) that uses the data to be signed instead of the hash of the data.
 
 #### Send along msg.sender to fallback handler
-Issue: [#246](https://github.com/safe-global/safe-contracts/issues/246)
+Issue: [#246](https://github.com/safe-global/safe-smart-account/issues/246)
 
 Expected behaviour:
 
@@ -447,21 +447,21 @@ When the Safe forwards a call to the fallback handler it will append the `msg.se
 Note: Fallback handlers should make sure that the connected Safe supports this, else this can be used by the caller to influence the fallback handler (by specifying an arbitrary `msg.sender`)
 
 #### Revert on failure if safeTxGas and gasPrice are 0
-Issue: [#274](https://github.com/safe-global/safe-contracts/issues/274)
+Issue: [#274](https://github.com/safe-global/safe-smart-account/issues/274)
 
 Expected behaviour:
 
 If `safeTxGas` is 0 (therefore all available gas has been used for the internal tx) and `gasPrice` is also 0 (therefore no refund is involved) the transaction will revert when the internal tx fails. This makes it easier to interact with the Safe without having to estimate the internal transaction ahead of time.
 
 #### Add setup event
-Issue: [#233](https://github.com/safe-global/safe-contracts/issues/233)
+Issue: [#233](https://github.com/safe-global/safe-smart-account/issues/233)
 
 Expected behaviour:
 
 The Safe now emits an event that contains all setup information that influences the State of the nearly setup Safe. The initializer calldata is omitted to prevent excessive gas costs. And the refund information is omitted as they don’t have an influence on the internal contract state.
 
 #### Add incoming ETH event
-Issue: [#209](https://github.com/safe-global/safe-contracts/issues/209)
+Issue: [#209](https://github.com/safe-global/safe-smart-account/issues/209)
 
 Expected behaviour:
 
@@ -471,7 +471,7 @@ Note: It will not be possible anymore to send ETH via the solidity calls transfe
 ### Layer 2
 
 #### Add contract version that emits Safe tx information via events
-File: [`contracts/GnosisSafeL2.sol`](https://github.com/safe-global/safe-contracts/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/GnosisSafeL2.sol)
+File: [`contracts/GnosisSafeL2.sol`](https://github.com/safe-global/safe-smart-account/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/GnosisSafeL2.sol)
 
 Expected behaviour:
 
@@ -486,25 +486,25 @@ Same can be done with the `SafeModuleTransaction` and `ExecutionFromModuleSucces
 ### Fallback handlers
 
 #### Add EIP-165 support to DefaultCallbackHandler
-Issue: [#161](https://github.com/safe-global/safe-contracts/issues/161)
+Issue: [#161](https://github.com/safe-global/safe-smart-account/issues/161)
 
-File: [`contracts/handler/DefaultCallbackHandler.sol`](https://github.com/safe-global/safe-contracts/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/handler/DefaultCallbackHandler.sol)
+File: [`contracts/handler/DefaultCallbackHandler.sol`](https://github.com/safe-global/safe-smart-account/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/handler/DefaultCallbackHandler.sol)
 
 Expected behaviour:
 
 Indicate via the `supportsInterface` method of [EIP-165](https://eips.ethereum.org/EIPS/eip-165) that the [EIP-721](https://eips.ethereum.org/EIPS/eip-721) and [EIP-1155](https://eips.ethereum.org/EIPS/eip-1155) receiver interfaces are supported. 
 
 #### Add CompatibilityFallbackHandler
-Issue: [#223](https://github.com/safe-global/safe-contracts/issues/223)
+Issue: [#223](https://github.com/safe-global/safe-smart-account/issues/223)
 
-File: [`contracts/handler/CompatibilityFallbackHandler.sol`](https://github.com/safe-global/safe-contracts/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/handler/CompatibilityFallbackHandler.sol)
+File: [`contracts/handler/CompatibilityFallbackHandler.sol`](https://github.com/safe-global/safe-smart-account/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/handler/CompatibilityFallbackHandler.sol)
 
 Expected behaviour:
 
 The `CompatibilityFallbackHandler` extends the `DefaultCallbackHandler` and implements support for some logic that has been removed from the core contracts. Namely [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) support and the non reverting method of the `StorageAccessible` contract. Also the fallback manager contains the logic to verify Safe messages.
 
 #### Add possibility to get sender in fallback handler
-File: [`contracts/handler/HandlerContext.sol`](https://github.com/safe-global/safe-contracts/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/handler/HandlerContext.sol)
+File: [`contracts/handler/HandlerContext.sol`](https://github.com/safe-global/safe-smart-account/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/handler/HandlerContext.sol)
 
 Expected behaviour:
 
@@ -513,7 +513,7 @@ The `HandlerContext` can be used to retrieve the `msg.sender` and the Safe (aka 
 ### Guard
 
 #### Add DelegateCallTransactionGuard
-File: [`contracts/examples/guards/DelegateCallTransactionGuard.sol`](https://github.com/safe-global/safe-contracts/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/examples/guards/DelegateCallTransactionGuard.sol)
+File: [`contracts/examples/guards/DelegateCallTransactionGuard.sol`](https://github.com/safe-global/safe-smart-account/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/examples/guards/DelegateCallTransactionGuard.sol)
 
 Note: **This contract is meant as an example to demonstrate how to facilitate a guard. This should not be used in production without further checks.**
 
@@ -522,7 +522,7 @@ Expected behaviour:
 This transaction guard can be used to prevent that Safe transactions that use a delegatecall operation are being executed. It is also possible to specify an exception when deploying the contract (e.g. a `MultiSendCallOnly` instance).
 
 #### Add DebugTransactionGuard
-File: [`contracts/examples/guards/DebugTransactionGuard.sol`](https://github.com/safe-global/safe-contracts/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/examples/guards/DebugTransactionGuard.sol)
+File: [`contracts/examples/guards/DebugTransactionGuard.sol`](https://github.com/safe-global/safe-smart-account/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/examples/guards/DebugTransactionGuard.sol)
 
 Note: **This contract is meant as an example to demonstrate how to facilitate a guard. This should not be used in production without further checks.**
 
@@ -531,7 +531,7 @@ Expected behaviour:
 This transaction guard can be used to log more details about a transaction. This is similar to what the L2 version of the Safe does, but implemented as a transaction guard. One event will be emitted containing the transaction details and another to track the status of a specific nonce.
 
 #### Add ReentrancyTransactionGuard
-File: [`contracts/examples/guards/ReentrancyTransactionGuard.sol`](https://github.com/safe-global/safe-contracts/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/examples/guards/ReentrancyTransactionGuard.sol)
+File: [`contracts/examples/guards/ReentrancyTransactionGuard.sol`](https://github.com/safe-global/safe-smart-account/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/examples/guards/ReentrancyTransactionGuard.sol)
 
 Note: **This contract is meant as an example to demonstrate how to facilitate a guard. This should not be used in production without further checks.**
 
@@ -542,16 +542,16 @@ This transaction guard can be used to prevent that Safe transactions can re-ente
 ### Libraries
 
 #### Make multiSend payable to avoid check on msg.value
-Issue: [#227](https://github.com/safe-global/safe-contracts/issues/227)
+Issue: [#227](https://github.com/safe-global/safe-smart-account/issues/227)
 
-File: [`contracts/libraries/MultiSend.sol`](https://github.com/safe-global/safe-contracts/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/libraries/MultiSend.sol)
+File: [`contracts/libraries/MultiSend.sol`](https://github.com/safe-global/safe-smart-account/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/libraries/MultiSend.sol)
 
 Expected behaviour:
 
 The `multiSend` is now payable therefore will enforce anymore that `msg.value` is 0. ETH that is not transferred out again will remain in `this` (the calling contract when used via a delegatecall or the contract when used via call, only possible with `MultiSendCallOnly`)
 
 #### Add MuliSend that disallows delegate operation
-File: [`contracts/libraries/MultiSendCallOnly.sol`](https://github.com/safe-global/safe-contracts/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/libraries/MultiSendCallOnly.sol)
+File: [`contracts/libraries/MultiSendCallOnly.sol`](https://github.com/safe-global/safe-smart-account/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/libraries/MultiSendCallOnly.sol)
 
 Expected behaviour:
 
@@ -559,7 +559,7 @@ The logic is the same as for the normal `MultiSend`, but when an attempt is made
 Note: The encoding of the data send to the `multiSend` method is exactly the same as for the normal `MultiSend`, this makes it easy to exchange the contracts depending on the use case.
 
 #### Add base contract for Safe storage layout
-File: [`contracts/examples/libraries/GnosisSafeStorage.sol`](https://github.com/safe-global/safe-contracts/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/examples/libraries/GnosisSafeStorage.sol)
+File: [`contracts/examples/libraries/GnosisSafeStorage.sol`](https://github.com/safe-global/safe-smart-account/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/examples/libraries/GnosisSafeStorage.sol)
 
 Note: **This contract is meant as an example to demonstrate how to access the Safe state within a library contract. This should not be used in production without further checks.**
 
@@ -568,7 +568,7 @@ Expected behaviour:
 The contract contains the basic storage layout of the `GnosisSafe.sol` contract.
 
 #### Add contract to mark Safe messages as signed
-File: [`contracts/examples/libraries/SignMessage.sol`](https://github.com/safe-global/safe-contracts/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/examples/libraries/SignMessage.sol)
+File: [`contracts/examples/libraries/SignMessage.sol`](https://github.com/safe-global/safe-smart-account/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/examples/libraries/SignMessage.sol)
 
 Note: **This contract is meant as an example to demonstrate how to mark Safe message as signed in the signedMessages mapping. This should not be used in production without further checks.**
 
@@ -577,7 +577,7 @@ Expected behaviour:
 The library is meant as a compatibility tool for the removed `signMessage` function from the pre-1.3.0 Safe contracts. It has the same signature and assumes the same storage layout as the previous Safe contract versions. After calling this function with a massage, the hash of that message should be marked as executed in the `signedMessages` mapping.
 
 #### Add Migration example to downgrade from 1.3.0 to 1.2.0
-File: [`contracts/examples/libraries/Migrate_1_3_0_to_1_2_0.sol`](https://github.com/safe-global/safe-contracts/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/examples/libraries/Migrate_1_3_0_to_1_2_0.sol)
+File: [`contracts/examples/libraries/Migrate_1_3_0_to_1_2_0.sol`](https://github.com/safe-global/safe-smart-account/blob/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9/contracts/examples/libraries/Migrate_1_3_0_to_1_2_0.sol)
 
 Note: **This contract is meant as an example to demonstrate how to facilitate migration in the future. This should not be used in production without further checks.**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog only contains changes starting from version 1.3.0
 
 # Version 1.5.0
 
+## Rename repository
+
+Issue: [#719](https://github.com/safe-global/safe-smart-account/issues/719)
+
+The repository was renamed from `safe-contracts` to `safe-smart-account` to better reflect the purpose of the contracts. Also, the npm package name was changed from `@safe-global/safe-contracts` to `@safe-global/safe-smart-account`.
+
 ## Compiler settings
 
 Solidity compiler: [0.7.6](https://github.com/ethereum/solidity/releases/tag/v0.7.6) (for more info see issue [#251](https://github.com/safe-global/safe-smart-account/issues/251))

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Note: Address will vary if contract code is changed or a different Solidity vers
 
 Some networks require replay protection, making it incompatible with the default deployment process as it relies on a presigned transaction without replay protection (see https://github.com/Arachnid/deterministic-deployment-proxy). 
 
-Safe contracts use a different deterministic deployment proxy (https://github.com/safe-global/safe-singleton-factory). To make sure that the latest version of this package is installed, make sure to run `npm i --save-dev @gnosis.pm/safe-singleton-factory` before deployment. For more information, including how to deploy the factory to a new network, please refer to the factory repo.  
+Safe Smart Account contract uses a different deterministic deployment proxy (https://github.com/safe-global/safe-singleton-factory). To make sure that the latest version of this package is installed, make sure to run `npm i --save-dev @gnosis.pm/safe-singleton-factory` before deployment. For more information, including how to deploy the factory to a new network, please refer to the factory repo.  
 
 Note: This will result in different addresses compared to hardhat's default deterministic deployment process.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-Safe Contracts
+Safe Smart Account
 ==============
 
-[![npm version](https://badge.fury.io/js/%40safe-global%2Fsafe-contracts.svg)](https://badge.fury.io/js/%40safe-global%2Fsafe-contracts)
-[![Build Status](https://github.com/safe-global/safe-contracts/workflows/safe-contracts/badge.svg?branch=main)](https://github.com/safe-global/safe-contracts/actions)
-[![Coverage Status](https://coveralls.io/repos/github/safe-global/safe-contracts/badge.svg?branch=main)](https://coveralls.io/github/safe-global/safe-contracts)
+[![npm version](https://badge.fury.io/js/%40safe-global%2Fsafe-smart-account.svg)](https://badge.fury.io/js/%40safe-global%2Fsafe-smart-account)
+[![Build Status](https://github.com/safe-global/safe-smart-account/workflows/safe-smart-account/badge.svg?branch=main)](https://github.com/safe-global/safe-smart-account/actions)
+[![Coverage Status](https://coveralls.io/repos/github/safe-global/safe-smart-account/badge.svg?branch=main)](https://coveralls.io/github/safe-global/safe-smart-account)
 
-> :warning: **This branch contains changes that are under development** To use the latest audited version make sure to use the correct commit. The tagged versions that are used by the Safe team can be found in the [releases](https://github.com/safe-global/safe-contracts/releases).
+> :warning: **This branch contains changes that are under development** To use the latest audited version make sure to use the correct commit. The tagged versions that are used by the Safe team can be found in the [releases](https://github.com/safe-global/safe-smart-account/releases).
 
 Usage
 -----
@@ -46,9 +46,9 @@ To add support for a new network follow the steps of the ``Deploy`` section and 
 
 ### Deploy
 
-> :warning: **Make sure to use the correct commit when deploying the contracts.** Any change (even comments) within the contract files will result in different addresses. The tagged versions that are used by the Safe team can be found in the [releases](https://github.com/safe-global/safe-contracts/releases).
+> :warning: **Make sure to use the correct commit when deploying the contracts.** Any change (even comments) within the contract files will result in different addresses. The tagged versions that are used by the Safe team can be found in the [releases](https://github.com/safe-global/safe-smart-account/releases).
 
-> **Current version:** The latest release is [v1.3.0-libs.0](https://github.com/safe-global/safe-contracts/tree/v1.3.0-libs.0) on the commit [767ef36](https://github.com/safe-global/safe-contracts/commit/767ef36bba88bdbc0c9fe3708a4290cabef4c376)
+> **Current version:** The latest release is [v1.3.0-libs.0](https://github.com/safe-global/safe-smart-account/tree/v1.3.0-libs.0) on the commit [767ef36](https://github.com/safe-global/safe-smart-account/commit/767ef36bba88bdbc0c9fe3708a4290cabef4c376)
 
 This will deploy the contracts deterministically and verify the contracts on etherscan using [Solidity 0.7.6](https://github.com/ethereum/solidity/releases/tag/v0.7.6) by default.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Note: Address will vary if contract code is changed or a different Solidity vers
 
 Some networks require replay protection, making it incompatible with the default deployment process as it relies on a presigned transaction without replay protection (see https://github.com/Arachnid/deterministic-deployment-proxy). 
 
-Safe Smart Account contract uses a different deterministic deployment proxy (https://github.com/safe-global/safe-singleton-factory). To make sure that the latest version of this package is installed, make sure to run `npm i --save-dev @gnosis.pm/safe-singleton-factory` before deployment. For more information, including how to deploy the factory to a new network, please refer to the factory repo.  
+Safe Smart Account contracts use a different deterministic deployment proxy (https://github.com/safe-global/safe-singleton-factory). To make sure that the latest version of this package is installed, make sure to run `npm i --save-dev @gnosis.pm/safe-singleton-factory` before deployment. For more information, including how to deploy the factory to a new network, please refer to the factory repo.  
 
 Note: This will result in different addresses compared to hardhat's default deterministic deployment process.
 

--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -214,7 +214,7 @@ contract Safe is
     /**
      * @notice Checks whether the contract signature is valid. Reverts otherwise.
      * @dev This is extracted to a separate function for better compatibility with Certora's prover.
-     *      More info here: https://github.com/safe-global/safe-contracts/pull/661
+     *      More info here: https://github.com/safe-global/safe-smart-account/pull/661
      * @param owner Address of the owner used to sign the message
      * @param dataHash Hash of the data (could be either a message hash or transaction hash)
      * @param signatures Signature data that should be verified.
@@ -292,7 +292,7 @@ contract Safe is
                 // The contract signature check is extracted to a separate function for better compatibility with formal verification
                 // A quote from the Certora team:
                 // "The assembly code broke the pointer analysis, which switched the prover in failsafe mode, where it is (a) much slower and (b) computes different hashes than in the normal mode."
-                // More info here: https://github.com/safe-global/safe-contracts/pull/661
+                // More info here: https://github.com/safe-global/safe-smart-account/pull/661
                 checkContractSignature(currentOwner, dataHash, signatures, uint256(s));
             } else if (v == 1) {
                 // If v is 1 then it is an approved hash

--- a/contracts/common/StorageAccessible.sol
+++ b/contracts/common/StorageAccessible.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.7.0 <0.9.0;
 /**
  * @title StorageAccessible - A generic base contract that allows callers to access all internal storage.
  * @notice See https://github.com/gnosis/util-contracts/blob/bb5fe5fb5df6d8400998094fb1b32a178a47c3a1/contracts/StorageAccessible.sol
- *         It removes a method from the original contract not needed for the Safe contracts.
+ *         It removes a method from the original contract not needed for the Safe Smart Account contracts.
  * @author Gnosis Developers
  */
 abstract contract StorageAccessible {

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -7,7 +7,7 @@ import {ISafe} from "../interfaces/ISafe.sol";
 import {HandlerContext} from "./HandlerContext.sol";
 
 /**
- * @title Compatibility Fallback Handler - Provides compatibility between pre 1.3.0 and 1.3.0+ Safe contracts.
+ * @title Compatibility Fallback Handler - Provides compatibility between pre 1.3.0 and 1.3.0+ Safe Smart Account contracts.
  * @author Richard Meissner - @rmeissner
  */
 contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidator, HandlerContext {

--- a/contracts/libraries/Enum.sol
+++ b/contracts/libraries/Enum.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 /**
- * @title Enum - Collection of enums used in Safe contracts.
+ * @title Enum - Collection of enums used in Safe Smart Account contracts.
  * @author @safe-global/safe-protocol
  */
 library Enum {

--- a/contracts/libraries/Safe150Migration.sol
+++ b/contracts/libraries/Safe150Migration.sol
@@ -27,7 +27,7 @@ contract Safe150Migration is SafeStorage {
     address public constant SAFE_150_FALLBACK_HANDLER = address(0x8aa755cB169991fEDC3E306751dCb71964A041c7);
 
     // the slot is defined as "keccak256("guard_manager.guard.address")" in the GuardManager contract
-    // reference: https://github.com/safe-global/safe-contracts/blob/8ffae95faa815acf86ec8b50021ebe9f96abde10/contracts/base/GuardManager.sol#L76-L77
+    // reference: https://github.com/safe-global/safe-smart-account/blob/8ffae95faa815acf86ec8b50021ebe9f96abde10/contracts/base/GuardManager.sol#L76-L77
     bytes32 internal constant GUARD_STORAGE_SLOT = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
 
     /**

--- a/contracts/libraries/SafeStorage.sol
+++ b/contracts/libraries/SafeStorage.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 /**
- * @title SafeStorage - Storage layout of the Safe contracts to be used in libraries.
+ * @title SafeStorage - Storage layout of the Safe Smart Account contract to be used in libraries.
  * @dev Should be always the first base contract of a library that is used with a Safe.
  * @author Richard Meissner - @rmeissner
  */

--- a/contracts/libraries/SafeStorage.sol
+++ b/contracts/libraries/SafeStorage.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 /**
- * @title SafeStorage - Storage layout of the Safe Smart Account contract to be used in libraries.
+ * @title SafeStorage - Storage layout of the Safe Smart Account contracts to be used in libraries.
  * @dev Should be always the first base contract of a library that is used with a Safe.
  * @author Richard Meissner - @rmeissner
  */

--- a/docs/alexey_audit.md
+++ b/docs/alexey_audit.md
@@ -4,9 +4,9 @@
 * Alexey Akhunov (<alexey@ledgerwatch.com>)
 
 ##### Notes
-The audit report was based on commit [942968d66a4fa200fe9757d02b377dbfc3c88636](https://github.com/safe-global/safe-contracts/commit/942968d66a4fa200fe9757d02b377dbfc3c88636)
+The audit report was based on commit [942968d66a4fa200fe9757d02b377dbfc3c88636](https://github.com/safe-global/safe-smart-account/commit/942968d66a4fa200fe9757d02b377dbfc3c88636)
 
-Changes made until commit [898cc8969736bc190db1b7c446e050f49177f898](https://github.com/safe-global/safe-contracts/commit/898cc8969736bc190db1b7c446e050f49177f898) have been checked with symbolic execution and can be found in the attached pdf (see table `SecuredTokenTransfer::transferToken`).
+Changes made until commit [898cc8969736bc190db1b7c446e050f49177f898](https://github.com/safe-global/safe-smart-account/commit/898cc8969736bc190db1b7c446e050f49177f898) have been checked with symbolic execution and can be found in the attached pdf (see table `SecuredTokenTransfer::transferToken`).
 
 ##### Files
 * [Audit Report](Gnosis_Safe_Audit_Report.pdf)

--- a/docs/audit_1_1_1.md
+++ b/docs/audit_1_1_1.md
@@ -6,11 +6,11 @@
   * Nick Munoz-McDonald (@NickErrant)
 
 ##### Notes
-All changes for 1.1.1 until commit [2df0b2e0ad5d0f7ab5423e7f5baa72b2456d32ae](https://github.com/safe-global/safe-contracts/commit/2df0b2e0ad5d0f7ab5423e7f5baa72b2456d32ae) have been audited and the result were added to an ammended report.
+All changes for 1.1.1 until commit [2df0b2e0ad5d0f7ab5423e7f5baa72b2456d32ae](https://github.com/safe-global/safe-smart-account/commit/2df0b2e0ad5d0f7ab5423e7f5baa72b2456d32ae) have been audited and the result were added to an ammended report.
 
-All changes for 1.1.0 until commit [78494bcdbc61b3db52308a25f0556c42cf656ab1](https://github.com/safe-global/safe-contracts/commit/78494bcdbc61b3db52308a25f0556c42cf656ab1) have been audited and are considered in the audit report.
+All changes for 1.1.0 until commit [78494bcdbc61b3db52308a25f0556c42cf656ab1](https://github.com/safe-global/safe-smart-account/commit/78494bcdbc61b3db52308a25f0556c42cf656ab1) have been audited and are considered in the audit report.
 
-The audit was initially performed on commit [1a9e5ce768e134c556770ea50e114fd83666b8a8](https://github.com/safe-global/safe-contracts/commit/1a9e5ce768e134c556770ea50e114fd83666b8a8)
+The audit was initially performed on commit [1a9e5ce768e134c556770ea50e114fd83666b8a8](https://github.com/safe-global/safe-smart-account/commit/1a9e5ce768e134c556770ea50e114fd83666b8a8)
 
 ##### Links
 * [Audit Report 1.1.1](https://github.com/g0-group/Audits/blob/master/G0Group-GnosisSafe-Ammended.pdf)

--- a/docs/audit_1_2_0.md
+++ b/docs/audit_1_2_0.md
@@ -6,7 +6,7 @@
   * Nick Munoz-McDonald (@NickErrant)
 
 ##### Notes
-The audit was performed on commit [62d4bd39925db65083b035115d6987772b2d2dca](https://github.com/safe-global/safe-contracts/commit/62d4bd39925db65083b035115d6987772b2d2dca)
+The audit was performed on commit [62d4bd39925db65083b035115d6987772b2d2dca](https://github.com/safe-global/safe-smart-account/commit/62d4bd39925db65083b035115d6987772b2d2dca)
 
 ##### Files
 * [Audit Report 1.2.0](Gnosis_Safe_Audit_Report_1_2_0.pdf)

--- a/docs/audit_1_3_0.md
+++ b/docs/audit_1_3_0.md
@@ -5,9 +5,9 @@
   * Adam Kolář (@adamkolar)
 
 ##### Notes
-An initial audit was performed on commit [4bfc0c8519f1893015d7edfd2c2780fca163c364](https://github.com/safe-global/safe-contracts/tree/4bfc0c8519f1893015d7edfd2c2780fca163c364) and contract changes until commit [9b305a0f80da7f1107d1181f52c844f089557d05](https://github.com/safe-global/safe-contracts/tree/9b305a0f80da7f1107d1181f52c844f089557d05) have been checked.
+An initial audit was performed on commit [4bfc0c8519f1893015d7edfd2c2780fca163c364](https://github.com/safe-global/safe-smart-account/tree/4bfc0c8519f1893015d7edfd2c2780fca163c364) and contract changes until commit [9b305a0f80da7f1107d1181f52c844f089557d05](https://github.com/safe-global/safe-smart-account/tree/9b305a0f80da7f1107d1181f52c844f089557d05) have been checked.
 
-The final audit was performed on commit [ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9](https://github.com/safe-global/safe-contracts/tree/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9).
+The final audit was performed on commit [ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9](https://github.com/safe-global/safe-smart-account/tree/ad6c7355d5bdf4f7fa348fbfcb9f07431769a3c9).
 
 
 ##### Files

--- a/docs/audit_1_4_0.md
+++ b/docs/audit_1_4_0.md
@@ -6,12 +6,12 @@
 
 ##### Notes
 
-The final audit was performed on commit [eb93dbb0f62e2dc1b308ac4c110038062df0a8c9](https://github.com/safe-global/safe-contracts/tree/eb93dbb0f62e2dc1b308ac4c110038062df0a8c9).
+The final audit was performed on commit [eb93dbb0f62e2dc1b308ac4c110038062df0a8c9](https://github.com/safe-global/safe-smart-account/tree/eb93dbb0f62e2dc1b308ac4c110038062df0a8c9).
 
 There has been one minor bugfix after the audit related to ERC-4337 opcode compatibility:
 
--   [Pull request](https://github.com/safe-global/safe-contracts/pull/572)
--   [Commit](https://github.com/safe-global/safe-contracts/commit/f8bd2159b64392d5b594f4e056be258ade2fefab)
+-   [Pull request](https://github.com/safe-global/safe-smart-account/pull/572)
+-   [Commit](https://github.com/safe-global/safe-smart-account/commit/f8bd2159b64392d5b594f4e056be258ade2fefab)
 
 A change of similar scope has been successfully audited in the 1.4.0 release. Therefore, after notifying the auditors, we concluded no re-audit was necessary.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -35,7 +35,7 @@ The message can be signed two ways on-chain and off-chain.
 
 #### Modules
 
-Modules add additional functionalities to the Safe contracts. They are smart contracts that implement the Safe’s functionality while separating module logic from the Safe’s core contract.
+Modules add additional functionalities to the Safe Smart Account contracts. They are smart contracts that implement the Safe’s functionality while separating module logic from the Safe’s core contract.
 
 A basic Safe does not require any modules. Adding and removing a module requires confirmation from all owners. Events are emitted whenever a module is added or removed and also whenever a module transaction was successful or failed.
 
@@ -140,4 +140,4 @@ If the refund parameter is set to true, the Safe will refund the gas costs to th
 
 #### Fallback contract
 
-A Fallback contract contains logic outside of the scope of the core Safe contracts, such as the token callback logic and/or logic that didn't fit into the core contracts because of bytecode size limitations.
+A Fallback contract contains logic outside of the scope of the core Safe Smart Account, such as the token callback logic and/or logic that didn't fit into the core contracts because of bytecode size limitations.

--- a/docs/rv_1_0_0.md
+++ b/docs/rv_1_0_0.md
@@ -4,9 +4,9 @@
 * Runtime Verification (https://github.com/runtimeverification)
 
 ##### Notes
-The formal verification was based on commit [427d6f7e779431333c54bcb4d4cde31e4d57ce96](https://github.com/safe-global/safe-contracts/commit/427d6f7e779431333c54bcb4d4cde31e4d57ce96) 
+The formal verification was based on commit [427d6f7e779431333c54bcb4d4cde31e4d57ce96](https://github.com/safe-global/safe-smart-account/commit/427d6f7e779431333c54bcb4d4cde31e4d57ce96) 
 
-Critical findings have been fixed with https://github.com/safe-global/safe-contracts/pull/90
+Critical findings have been fixed with https://github.com/safe-global/safe-smart-account/pull/90
 
 ##### Files
 * [Formal Verification Report](Gnosis_Safe_Formal_Verification_Report_1_0_0.pdf)

--- a/docs/safe_tx_gas.md
+++ b/docs/safe_tx_gas.md
@@ -1,6 +1,6 @@
 ### Safe Transaction Gas Limit (safeTxGas)
 
-In this document will describe the behaviour of the internal gas limit (aka `safeTxGas`) for the [1.3.0](https://github.com/safe-global/safe-smart-account/releases/tag/v1.3.0-libs.0) version of the Safe Contracts.
+In this document will describe the behaviour of the internal gas limit (aka `safeTxGas`) for the [1.3.0](https://github.com/safe-global/safe-smart-account/releases/tag/v1.3.0-libs.0) version of the Safe Smart Account.
 
 There have been changes to this behaviour with the [1.3.0](https://github.com/safe-global/safe-smart-account/blob/main/CHANGELOG.md#version-130) version of the Safe contract (see [#274](https://github.com/safe-global/safe-smart-account/issues/274))
 
@@ -8,7 +8,7 @@ The behaviour of `safeTxGas` depends on the `gasPrice` value of the Safe transac
 
 #### With gas refund
 
-If `gasPrice` is set to a value `>0` the Safe contracts will issue a refund for the gas costs incurred the execution of the Safe transaction. An example where this can be used is the relayers. These would execute the Safe transaction after it has been signed by the owners and then would get refunded for the execution.
+If `gasPrice` is set to a value `>0` the Safe Smart Account will issue a refund for the gas costs incurred the execution of the Safe transaction. An example where this can be used is the relayers. These would execute the Safe transaction after it has been signed by the owners and then would get refunded for the execution.
 
 The logic for this can be seen in [`Safe.sol`](https://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L183-L185):
 
@@ -26,11 +26,11 @@ This also results in the `nonce` of this transaction being used, so it is not po
 
 #### Without gas refund
 
-If `gasPrice` is set to `0` then the Safe contracts will **not** issue a refund after the Safe transaction execution.
+If `gasPrice` is set to `0` then the Safe Smart Account will **not** issue a refund after the Safe transaction execution.
 
-Therefore it is not necessary to be as strict on the gas being passed along with the execution of the Safe transaction. As no refund is triggered the Safe will not pay for the execution costs, based on this the Safe contracts will send along all available case when no refund is used.
+Therefore it is not necessary to be as strict on the gas being passed along with the execution of the Safe transaction. As no refund is triggered the Safe will not pay for the execution costs, based on this the Safe Smart Account will send along all available case when no refund is used.
 
-Before the execution the Safe contracts always check if enough gas is available to satisfy the `safeTxGas`. This can be seen in [`Safe.sol`](hhttps://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L168-L170):
+Before the execution the Safe Smart Account always check if enough gas is available to satisfy the `safeTxGas`. This can be seen in [`Safe.sol`](hhttps://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L168-L170):
 
 ```js
 require(gasleft() >=
@@ -43,9 +43,9 @@ If the Safe transaction fails (e.g. because of a revert in the target contract o
 
 This essentially means if you set a `safeTxGas` that is too low, your transaction might fail with out of gas and it is not possible to retry the same transaction, therefore it is important to set a correct `safeTxGas` value.
 
-Most wallets will estimate Ethereum transaction by checking with what gas limit the transaction does not revert. As the Safe contracts will "catch" the internal revert, most wallets will estimate the gas limit to the minimum value required to satisfy the `safeTxGas`. This makes it very important to correctly estimate the `safeTxGas` value.
+Most wallets will estimate Ethereum transaction by checking with what gas limit the transaction does not revert. As the Safe Smart Account contracts will "catch" the internal revert, most wallets will estimate the gas limit to the minimum value required to satisfy the `safeTxGas`. This makes it very important to correctly estimate the `safeTxGas` value.
 
-To make it easier to set the `safeTxGas` value a change has been made with the 1.3.0 version of the Safe contracts:
+To make it easier to set the `safeTxGas` value a change has been made with the 1.3.0 version of the Safe Smart Account contracts:
 
 **When `safeTxGas` is set to `0`, the Safe contract will revert if the internal Safe transaction fails** (see [#274](https://github.com/safe-global/safe-smart-account/issues/274))
 

--- a/docs/safe_tx_gas.md
+++ b/docs/safe_tx_gas.md
@@ -1,8 +1,8 @@
 ### Safe Transaction Gas Limit (safeTxGas)
 
-In this document will describe the behaviour of the internal gas limit (aka `safeTxGas`) for the [1.3.0](https://github.com/safe-global/safe-contracts/releases/tag/v1.3.0-libs.0) version of the Safe Contracts.
+In this document will describe the behaviour of the internal gas limit (aka `safeTxGas`) for the [1.3.0](https://github.com/safe-global/safe-smart-account/releases/tag/v1.3.0-libs.0) version of the Safe Contracts.
 
-There have been changes to this behaviour with the [1.3.0](https://github.com/safe-global/safe-contracts/blob/main/CHANGELOG.md#version-130) version of the Safe contract (see [#274](https://github.com/safe-global/safe-contracts/issues/274))
+There have been changes to this behaviour with the [1.3.0](https://github.com/safe-global/safe-smart-account/blob/main/CHANGELOG.md#version-130) version of the Safe contract (see [#274](https://github.com/safe-global/safe-smart-account/issues/274))
 
 The behaviour of `safeTxGas` depends on the `gasPrice` value of the Safe transaction.
 
@@ -10,7 +10,7 @@ The behaviour of `safeTxGas` depends on the `gasPrice` value of the Safe transac
 
 If `gasPrice` is set to a value `>0` the Safe contracts will issue a refund for the gas costs incurred the execution of the Safe transaction. An example where this can be used is the relayers. These would execute the Safe transaction after it has been signed by the owners and then would get refunded for the execution.
 
-The logic for this can be seen in [`Safe.sol`](https://github.com/safe-global/safe-contracts/blob/main/contracts/Safe.sol#L183-L185):
+The logic for this can be seen in [`Safe.sol`](https://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L183-L185):
 
 ```js
 if (gasPrice > 0) {
@@ -30,7 +30,7 @@ If `gasPrice` is set to `0` then the Safe contracts will **not** issue a refund 
 
 Therefore it is not necessary to be as strict on the gas being passed along with the execution of the Safe transaction. As no refund is triggered the Safe will not pay for the execution costs, based on this the Safe contracts will send along all available case when no refund is used.
 
-Before the execution the Safe contracts always check if enough gas is available to satisfy the `safeTxGas`. This can be seen in [`Safe.sol`](hhttps://github.com/safe-global/safe-contracts/blob/main/contracts/Safe.sol#L168-L170):
+Before the execution the Safe contracts always check if enough gas is available to satisfy the `safeTxGas`. This can be seen in [`Safe.sol`](hhttps://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L168-L170):
 
 ```js
 require(gasleft() >=
@@ -47,9 +47,9 @@ Most wallets will estimate Ethereum transaction by checking with what gas limit 
 
 To make it easier to set the `safeTxGas` value a change has been made with the 1.3.0 version of the Safe contracts:
 
-**When `safeTxGas` is set to `0`, the Safe contract will revert if the internal Safe transaction fails** (see [#274](https://github.com/safe-global/safe-contracts/issues/274))
+**When `safeTxGas` is set to `0`, the Safe contract will revert if the internal Safe transaction fails** (see [#274](https://github.com/safe-global/safe-smart-account/issues/274))
 
-That means if `safeTxGas` is set to `0` the Safe contract sends along all the available gas when performing the internal Safe transaction. If that transaction fails the Safe will revert and therefore also undo all State changes. This can be seen in [`Safe.sol`](https://github.com/safe-global/safe-contracts/blob/main/contracts/Safe.sol#L178-L180):
+That means if `safeTxGas` is set to `0` the Safe contract sends along all the available gas when performing the internal Safe transaction. If that transaction fails the Safe will revert and therefore also undo all State changes. This can be seen in [`Safe.sol`](https://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L178-L180):
 
 ```js
 require(success || safeTxGas != 0 || gasPrice != 0, "GS013");

--- a/docs/signatures.md
+++ b/docs/signatures.md
@@ -64,7 +64,7 @@ The method `signMessage` can be used to mark a message as signed on-chain.
 
 `{32-bytes hash validator}{32-bytes ignored}{1-byte signature type}`
 
-**Hash validator** - Padded address of the account that pre-validated the hash that should be validated. The Safe keeps track of all hashes that have been pre validated. This is done with a **mapping address to mapping of bytes32 to boolean** where it is possible to set a hash as validated by a certain address \(hash validator\). To add an entry to this mapping use `approveHash`. Also if the validator is the sender of transaction that executed the Safe transaction it is **not** required to use `approveHash` to add an entry to the mapping. \(This can be seen in the [Team Edition tests](https://github.com/gnosis/safe-contracts/blob/v1.0.0/test/gnosisSafeTeamEdition.js)\)
+**Hash validator** - Padded address of the account that pre-validated the hash that should be validated. The Safe keeps track of all hashes that have been pre validated. This is done with a **mapping address to mapping of bytes32 to boolean** where it is possible to set a hash as validated by a certain address \(hash validator\). To add an entry to this mapping use `approveHash`. Also if the validator is the sender of transaction that executed the Safe transaction it is **not** required to use `approveHash` to add an entry to the mapping. \(This can be seen in the [Team Edition tests](https://github.com/gnosis/safe-smart-account/blob/v1.0.0/test/gnosisSafeTeamEdition.js)\)
 
 **Signature type** - 1
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -48,7 +48,7 @@ const deterministicDeployment = (network: string): DeterministicDeploymentInfo =
     if (!info) {
         throw new Error(`
         Safe factory not found for network ${network}. You can request a new deployment at https://github.com/safe-global/safe-singleton-factory.
-        For more information, see https://github.com/safe-global/safe-contracts#replay-protection-eip-155
+        For more information, see https://github.com/safe-global/safe-smart-account#replay-protection-eip-155
       `);
     }
     return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@safe-global/safe-contracts",
+    "name": "@safe-global/safe-smart-account",
     "version": "1.4.1-build.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@safe-global/safe-contracts",
+            "name": "@safe-global/safe-smart-account",
             "version": "1.4.1-build.0",
             "license": "LGPL-3.0",
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-    "name": "@safe-global/safe-contracts",
+    "name": "@safe-global/safe-smart-account",
     "version": "1.4.1-build.0",
     "description": "Ethereum multisig contract",
-    "homepage": "https://github.com/safe-global/safe-contracts/",
+    "homepage": "https://github.com/safe-global/safe-smart-account/",
     "license": "LGPL-3.0",
     "main": "dist/src/index.js",
     "typings": "dist/src/index.d.ts",
@@ -39,7 +39,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/safe-global/safe-contracts.git"
+        "url": "git+https://github.com/safe-global/safe-smart-account.git"
     },
     "keywords": [
         "Ethereum",
@@ -48,7 +48,7 @@
     ],
     "author": "richard@safe.global",
     "bugs": {
-        "url": "https://github.com/safe-global/safe-contracts/issues"
+        "url": "https://github.com/safe-global/safe-smart-account/issues"
     },
     "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^4.0.0",

--- a/src/tasks/deploy_contracts.ts
+++ b/src/tasks/deploy_contracts.ts
@@ -1,6 +1,6 @@
 import { task } from "hardhat/config";
 
-task("deploy-contracts", "Deploys and verifies Safe contracts").setAction(async (_, hre) => {
+task("deploy-contracts", "Deploys and verifies Safe Smart Account contracts").setAction(async (_, hre) => {
     await hre.run("deploy");
     await hre.run("local-verify");
     await hre.run("sourcify");


### PR DESCRIPTION
Fixes #719 

Changes in PR:
- Find and replace all instances of `safe-contracts` with `safe-smart-account`