### PR TITLE
Remove OR operator from the benchmark job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,9 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                solidity: ["0.7.6", "0.8.19"]
+                solidity: ["0.7.6", "0.8.24"]
                 include:
-                    - solidity: "0.8.19"
+                    - solidity: "0.8.24"
                       settings: '{"viaIR":true,"optimizer":{"enabled":true,"runs":1000000}}'
         env:
             SOLIDITY_VERSION: ${{ matrix.solidity }}
@@ -81,4 +81,4 @@ jobs:
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   cache: "npm"
-            - run: (npm ci && npm run build && npx hardhat codesize --contractname Safe && npm run benchmark) || echo "Benchmark failed"
+            - run: npm ci && npm run build && npx hardhat codesize --contractname Safe && npm run benchmark


### PR DESCRIPTION
This PR:
- Fix the benchmark CI job to prebent regressions like https://github.com/safe-global/safe-smart-account/issues/735. It is fixed by removing the OR operator because if a benchmark failed, it only outputted a message but didn't return a non-zero exit code.
- Also bumps the `0.8.x` compiler version to the latest one (0.8.24)