### PR TITLE
chore: remove useless `and` op

### DIFF
--- a/contracts/proxies/SafeProxy.sol
+++ b/contracts/proxies/SafeProxy.sol
@@ -36,7 +36,7 @@ contract SafeProxy {
             let _singleton := sload(0)
             // 0xa619486e == keccak("masterCopy()"). The value is right padded to 32-bytes with 0s
             if eq(calldataload(0), 0xa619486e00000000000000000000000000000000000000000000000000000000) {
-                mstore(0, _singleton)
+                mstore(0, and(_singleton, 0xffffffffffffffffffffffffffffffffffffffff))
                 return(0, 0x20)
             }
             calldatacopy(0, 0, calldatasize())

--- a/contracts/proxies/SafeProxy.sol
+++ b/contracts/proxies/SafeProxy.sol
@@ -33,7 +33,7 @@ contract SafeProxy {
     fallback() external payable {
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            let _singleton := and(sload(0), 0xffffffffffffffffffffffffffffffffffffffff)
+            let _singleton := sload(0)
             // 0xa619486e == keccak("masterCopy()"). The value is right padded to 32-bytes with 0s
             if eq(calldataload(0), 0xa619486e00000000000000000000000000000000000000000000000000000000) {
                 mstore(0, _singleton)

--- a/contracts/proxies/SafeProxy.sol
+++ b/contracts/proxies/SafeProxy.sol
@@ -36,7 +36,7 @@ contract SafeProxy {
             let _singleton := sload(0)
             // 0xa619486e == keccak("masterCopy()"). The value is right padded to 32-bytes with 0s
             if eq(calldataload(0), 0xa619486e00000000000000000000000000000000000000000000000000000000) {
-                mstore(0, and(_singleton, 0xffffffffffffffffffffffffffffffffffffffff))
+                mstore(0, shr(12, shl(12, _singleton)))
                 return(0, 0x20)
             }
             calldatacopy(0, 0, calldatasize())


### PR DESCRIPTION
`sload` always returns `32` bytes, so no need to truncate.