### PR TITLE
Update Compatibility Signature Verification Functions

### DIFF
--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -249,11 +249,6 @@ contract Safe is
 
     // @inheritdoc ISafe
     function checkSignatures(bytes32 dataHash, bytes memory signatures) public view override {
-        checkSignatures(dataHash, "", signatures);
-    }
-
-    // @inheritdoc ISafe
-    function checkSignatures(bytes32 dataHash, bytes memory /* IGNORED */, bytes memory signatures) public view override {
         // Load threshold to avoid multiple storage loads
         uint256 _threshold = threshold;
         // Check that a threshold is set
@@ -313,6 +308,37 @@ contract Safe is
                 revertWithError("GS026");
             lastOwner = currentOwner;
         }
+    }
+
+    /**
+     * @notice Checks whether the signature provided is valid for the provided hash. Reverts otherwise.
+     *         The `data` parameter is completely ignored during signature verification.
+     * @dev This function is provided for compatibility with previous versions.
+     *      Use `checkSignatures(bytes32,bytes)` instead.
+     * @param dataHash Hash of the data (could be either a message hash or transaction hash).
+     * @param data **IGNORED** The data pre-image.
+     * @param signatures Signature data that should be verified.
+     *                   Can be packed ECDSA signature ({bytes32 r}{bytes32 s}{uint8 v}), contract signature (EIP-1271) or approved hash.
+     */
+    function checkSignatures(bytes32 dataHash, bytes calldata data, bytes memory signatures) external view {
+        data;
+        checkSignatures(dataHash, signatures);
+    }
+
+    /**
+     * @notice Checks whether the signature provided is valid for the provided hash. Reverts otherwise.
+     *         The `data` parameter is completely ignored during signature verification.
+     * @dev This function is provided for compatibility with previous versions.
+     *      Use `checkNSignatures(address,bytes32,bytes,uint256)` instead.
+     * @param dataHash Hash of the data (could be either a message hash or transaction hash)
+     * @param data **IGNORED** The data pre-image.
+     * @param signatures Signature data that should be verified.
+     *                   Can be packed ECDSA signature ({bytes32 r}{bytes32 s}{uint8 v}), contract signature (EIP-1271) or approved hash.
+     * @param requiredSignatures Amount of required valid signatures.
+     */
+    function checkNSignatures(bytes32 dataHash, bytes calldata data, bytes memory signatures, uint256 requiredSignatures) external view {
+        data;
+        checkNSignatures(msg.sender, dataHash, signatures, requiredSignatures);
     }
 
     // @inheritdoc ISafe

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -157,24 +157,4 @@ contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidat
         }
         /* solhint-enable no-inline-assembly */
     }
-
-    /**
-     * @notice Checks whether the signature provided is valid for the provided data and hash. Reverts otherwise.
-     * @dev Since the EIP-1271 does an external call, be mindful of reentrancy attacks.
-     *      The function was moved to the fallback handler as a part of
-     *      1.5.0 contract upgrade. It used to be a part of the Safe core contract, but
-     *      was replaced by the same function that also accepts an executor address.
-     * @param dataHash Hash of the data (could be either a message hash or transaction hash)
-     * @param signatures Signature data that should be verified.
-     *                   Can be packed ECDSA signature ({bytes32 r}{bytes32 s}{uint8 v}), contract signature (EIP-1271) or approved hash.
-     * @param requiredSignatures Amount of required valid signatures.
-     */
-    function checkNSignatures(
-        bytes32 dataHash,
-        bytes memory /* IGNORED */,
-        bytes memory signatures,
-        uint256 requiredSignatures
-    ) public view {
-        ISafe(payable(_manager())).checkNSignatures(_msgSender(), dataHash, signatures, requiredSignatures);
-    }
 }

--- a/contracts/interfaces/ISafe.sol
+++ b/contracts/interfaces/ISafe.sol
@@ -84,15 +84,6 @@ interface ISafe is IModuleManager, IOwnerManager, IFallbackManager {
 
     /**
      * @notice Checks whether the signature provided is valid for the provided data and hash. Reverts otherwise.
-     * @param dataHash Hash of the data (could be either a message hash or transaction hash)
-     * @param signatures Signature data that should be verified.
-     *                   Can be packed ECDSA signature ({bytes32 r}{bytes32 s}{uint8 v}), contract signature (EIP-1271) or approved hash.
-     * @dev This function makes it compatible with previous versions.
-     */
-    function checkSignatures(bytes32 dataHash, bytes memory /* IGNORED */, bytes memory signatures) external view;
-
-    /**
-     * @notice Checks whether the signature provided is valid for the provided data and hash. Reverts otherwise.
      * @dev Since the EIP-1271 does an external call, be mindful of reentrancy attacks.
      * @param executor Address that executing the transaction.
      *        ⚠️⚠️⚠️ Make sure that the executor address is a legitmate executor.


### PR DESCRIPTION
I was trying to move the signature verification logic to use `calldata` instead of `memory` for the signature bytes and decided to make some small changes to the documentation around the legacy `checkSignatures` functions.

Additionally, since we have additional code size, we were able to move the legacy `checkSignatures` back into the `Safe` contract so continued compatibility with existing Safes does not require specific fallback handlers.