### PR TITLE
V1.4.1: Singleton factory update

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To add support for a new network follow the steps of the ``Deploy`` section and 
 
 > :warning: **Make sure to use the correct commit when deploying the contracts.** Any change (even comments) within the contract files will result in different addresses. The tagged versions that are used by the Safe team can be found in the [releases](https://github.com/safe-global/safe-contracts/releases).
 
-> **Current version:** The latest release is [v1.3.0-libs.0](https://github.com/safe-global/safe-contracts/tree/v1.3.0-libs.0) on the commit [767ef36](https://github.com/safe-global/safe-contracts/commit/767ef36bba88bdbc0c9fe3708a4290cabef4c376)
+> **Current version:** The latest release is [v1.4.1-build.0](https://github.com/safe-global/safe-smart-account/tree/v1.4.1-build.0) on the commit [192c7dc](https://github.com/safe-global/safe-smart-account/commit/192c7dc67290940fcbc75165522bb86a37187069)
 
 This will deploy the contracts deterministically and verify the contracts on etherscan using [Solidity 0.7.6](https://github.com/ethereum/solidity/releases/tag/v0.7.6) by default.
 
@@ -84,7 +84,7 @@ Note: Address will vary if contract code is changed or a different Solidity vers
 
 Some networks require replay protection, making it incompatible with the default deployment process as it relies on a presigned transaction without replay protection (see https://github.com/Arachnid/deterministic-deployment-proxy). 
 
-Safe contracts use a different deterministic deployment proxy (https://github.com/safe-global/safe-singleton-factory). To make sure that the latest version of this package is installed, make sure to run `yarn add @gnosis.pm/safe-singleton-factory` before deployment. For more information, including how to deploy the factory to a new network, please refer to the factory repo.  
+Safe Smart Account contracts use a different deterministic deployment proxy (https://github.com/safe-global/safe-singleton-factory). To make sure that the latest version of this package is installed, run `yarn add -D @safe-global/safe-singleton-factory` before deployment. For more information, including deploying the factory to a new network, please refer to the factory repo.  
 
 Note: This will result in different addresses compared to hardhat's default deterministic deployment process.
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,7 +6,7 @@ import "solidity-coverage";
 import "hardhat-deploy";
 import dotenv from "dotenv";
 import yargs from "yargs";
-import { getSingletonFactoryInfo } from "@gnosis.pm/safe-singleton-factory";
+import { getSingletonFactoryInfo } from "@safe-global/safe-singleton-factory";
 
 const argv = yargs
     .option("network", {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     },
     "devDependencies": {
         "@gnosis.pm/mock-contract": "^4.0.0",
-        "@gnosis.pm/safe-singleton-factory": "^1.0.14",
+        "@safe-global/safe-singleton-factory": "^1.0.30",
         "@nomiclabs/hardhat-ethers": "2.0.2",
         "@nomiclabs/hardhat-etherscan": "^3.1.7",
         "@nomiclabs/hardhat-waffle": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -840,11 +840,6 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/mock-contract/-/mock-contract-4.0.0.tgz#eaf500fddcab81b5f6c22280a7b22ff891dd6f87"
   integrity sha512-SkRq2KwPx6vo0LAjSc8JhgQstrQFXRyn2yqquIfub7r2WHi5nUbF8beeSSXsd36hvBcQxQfmOIYNYRpj9JOhrQ==
 
-"@gnosis.pm/safe-singleton-factory@^1.0.14":
-  version "1.0.14"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-singleton-factory/-/safe-singleton-factory-1.0.14.tgz#42dae9a91fda21b605f94bfe310a7fccc6a4d738"
-  integrity sha512-xZ26c9uKzpd5Sm8ux0sZHt5QC8n+Q2z1/X5xjPnd8aT5EcKH5t1GgLbAqjrMFmXVIOkiWSc7wi2Bj4XfgtiyaQ==
-
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"
@@ -1179,6 +1174,11 @@
     hosted-git-info "^2.6.0"
     path-browserify "^1.0.0"
     url "^0.11.0"
+
+"@safe-global/safe-singleton-factory@^1.0.30":
+  version "1.0.30"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-singleton-factory/-/safe-singleton-factory-1.0.30.tgz#c58c3b81fde6355037ff3a1dc7900a4be867b7f0"
+  integrity sha512-r4DTl0V+HvK5vhZo+Inx6/jUxMilPr2bASzDbZlmuRBlcqUwWbeC0f+0pAYiUkUTm2hE9JoRvNPcxFXN98caKA==
 
 "@scure/base@~1.1.0":
   version "1.1.1"


### PR DESCRIPTION
V1.4.1 Currently uses the outdated version of the safe-singleton factory, which confuses developers when it comes to deploying contracts as it requires them to do a few manual steps before deploying. This PR updates the readme and the package used, when merged we can prepare a new release with the updated factory