### PR TITLE
Remove reference to inexisting 'deploy' variable in SafeToL2Setup deployment

### DIFF
--- a/src/deploy/deploy_libraries.ts
+++ b/src/deploy/deploy_libraries.ts
@@ -36,7 +36,7 @@ const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     });
 
     await deploy("SafeToL2Setup", {
-        from: deployer,
+        from: deployerAccount,
         args: [],
         log: true,
         deterministicDeployment: true,


### PR DESCRIPTION
merging #742 broke the build because it used a different deployer account. This PR fixes it by using the new one in the SafeToL2Setup contract deployment