### PR TITLE
Better variable naming of the SafeTx struct hash in EIP-712 hashing

### DIFF
--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -412,7 +412,7 @@ contract Safe is
         address refundReceiver,
         uint256 _nonce
     ) private view returns (bytes memory) {
-        bytes32 safeTxHash = keccak256(
+        bytes32 safeTxStructHash = keccak256(
             abi.encode(
                 SAFE_TX_TYPEHASH,
                 to,
@@ -427,7 +427,7 @@ contract Safe is
                 _nonce
             )
         );
-        return abi.encodePacked(bytes1(0x19), bytes1(0x01), domainSeparator(), safeTxHash);
+        return abi.encodePacked(bytes1(0x19), bytes1(0x01), domainSeparator(), safeTxStructHash);
     }
 
     /**


### PR DESCRIPTION
This pull request includes changes in the `Safe` contract in the `contracts/Safe.sol` file. The changes involve renaming a variable for clarity.

Variable renaming for clarity:

* [`contracts/Safe.sol`](diffhunk://#diff-587b494ea631bb6b7adf4fc3e1a2e6a277a385ff16e1163b26e39de24e9483deL415-R415): Renamed the variable `safeTxHash` to `safeTxStructHash` to better reflect its purpose in the `encodeTransactionData` function. [[1]](diffhunk://#diff-587b494ea631bb6b7adf4fc3e1a2e6a277a385ff16e1163b26e39de24e9483deL415-R415) [[2]](diffhunk://#diff-587b494ea631bb6b7adf4fc3e1a2e6a277a385ff16e1163b26e39de24e9483deL430-R430)