### PR TITLE
Update `CHANGELOG` to Note Removal of `encodeTransactionData`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,7 @@ Previously pre-approved signatures relying on the `msg.sender` variable couldn't
 
 PR: [#603](https://github.com/safe-global/safe-smart-account/pull/603)
 
-To fit all of the above changes into the bytecode size limit, the `encodeTransactionData` method was made private. Please note that in the PR [#847](https://github.com/safe-global/safe-smart-account/pull/847), the function `encodeTransactionData` has been removed and replaced with an optimized and inlined assembly version.
+To fit all of the above changes into the bytecode size limit, the `encodeTransactionData` method was made private. Please note that in the subsequent PR [#847](https://github.com/safe-global/safe-smart-account/pull/847), the function `encodeTransactionData` has been completely removed and replaced with an optimized and inlined assembly version.
 
 # Version 1.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,7 +159,9 @@ Previously pre-approved signatures relying on the `msg.sender` variable couldn't
 
 #### `encodeTransactionData` public method removal
 
-To fit all of the above changes into the bytecode size limit, the `encodeTransactionData` method was made private.
+PR: [#603](https://github.com/safe-global/safe-smart-account/pull/603)
+
+To fit all of the above changes into the bytecode size limit, the `encodeTransactionData` method was made private. Please note that in the PR [#847](https://github.com/safe-global/safe-smart-account/pull/847), the function `encodeTransactionData` has been removed and replaced with an optimized and inlined assembly version.
 
 # Version 1.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,7 @@ Issues:
 
 Previously pre-approved signatures relying on the `msg.sender` variable couldn't be used in guards or modules without duplicating the logic within the module itself. This is now improved by adding an overloaded `checkNSignatures` method that accepts a `msg.sender` parameter. This allows the module to pass the `msg.sender` variable to the `checkNSignatures` method and use the pre-approved signatures. The old method was moved from the core contract to the `CompatibilityFallbackHandler`.
 
-#### Removal of `encodeTransactionData` and Inline-Assembly-Based Encoding in `getTransactionHash`
+#### Remove `encodeTransactionData` and add inline-assembly-based encoding in `getTransactionHash`
 
 PR: [#603](https://github.com/safe-global/safe-smart-account/pull/603)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,12 +106,6 @@ PR: [#851](https://github.com/safe-global/safe-smart-account/pull/851)
 
 `ExtensibleFallbackHandler` originally created by the CoWSwap Team is used for bringing new features and capabilities to Safe Smart Account including, but not limited to swaps, TWAP orders, etc. More details can be found [here](https://cow.fi/learn/all-you-need-to-know-about-cow-swap-new-safe-fallback-handler).
 
-#### Using assembly for encoding transaction data in `getTransactionHash(...)`
-
-PR: [#847](https://github.com/safe-global/safe-smart-account/pull/847)
-
-Using assembly for encoding transaction data resulted is better gas savings per call as well as overall decrease in codesize.
-
 #### Event emitted with `initializer` and `saltNonce` for proxy creation
 
 PR: [849](https://github.com/safe-global/safe-smart-account/pull/849)
@@ -157,7 +151,7 @@ Issues:
 
 Previously pre-approved signatures relying on the `msg.sender` variable couldn't be used in guards or modules without duplicating the logic within the module itself. This is now improved by adding an overloaded `checkNSignatures` method that accepts a `msg.sender` parameter. This allows the module to pass the `msg.sender` variable to the `checkNSignatures` method and use the pre-approved signatures. The old method was moved from the core contract to the `CompatibilityFallbackHandler`.
 
-#### `encodeTransactionData` public method removal
+#### Removal of `encodeTransactionData` and Inline-Assembly-Based Encoding in `getTransactionHash`
 
 PR: [#603](https://github.com/safe-global/safe-smart-account/pull/603)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,7 @@ Previously pre-approved signatures relying on the `msg.sender` variable couldn't
 
 PR: [#603](https://github.com/safe-global/safe-smart-account/pull/603)
 
-To fit all of the above changes into the bytecode size limit, the `encodeTransactionData` method was made private. Please note that in the subsequent PR [#847](https://github.com/safe-global/safe-smart-account/pull/847), the function `encodeTransactionData` has been completely removed and replaced with an optimized and inlined assembly version.
+The `encodeTransactionData` function has been refactored in two stages since the last release. Initially, due to bytecode size constraints, it was modified in PR [#603](https://github.com/safe-global/safe-smart-account/pull/603) to a `private` function. Subsequently, in PR [#847](https://github.com/safe-global/safe-smart-account/pull/847), `encodeTransactionData` was entirely removed and replaced with an optimized, inline-assembly implementation within the `getTransactionHash` function.
 
 # Version 1.4.1
 


### PR DESCRIPTION
### 🕓 Changelog

This PR adds a note in the `CHANGELOG` indicating that the `private` function `encodeTransactionData` has been completely removed and replaced with an optimised inline-assembly version via PR [#847](https://github.com/safe-global/safe-smart-account/pull/847).