### PR TITLE
correction comment 

### DIFF
--- a/certora/mocks/ModuleGuardMock.sol
+++ b/certora/mocks/ModuleGuardMock.sol
@@ -38,7 +38,7 @@ contract ModuleGuardMock is IModuleGuard {
         Enum.Operation operation,
         address module
     ) external override returns (bytes32 moduleTxHash) {
-        // updates transaction checked
+        // updates the transaction as checked
         preCheckedTransactions = true ;
         // if it passes, it returns a string of bytes
         return bytes32(0);

--- a/certora/mocks/ModuleGuardMockDuplicate.sol
+++ b/certora/mocks/ModuleGuardMockDuplicate.sol
@@ -38,7 +38,7 @@ contract ModuleGuardMockDuplicate is IModuleGuard {
         Enum.Operation operation,
         address module
     ) external override returns (bytes32 moduleTxHash) {
-        // updates transaction checked
+        // updates the transaction as checked
         preCheckedTransactions = true ;
         // if it passes, it returns a string of bytes
         return bytes32(0);

--- a/certora/mocks/TxnGuardMock.sol
+++ b/certora/mocks/TxnGuardMock.sol
@@ -46,7 +46,7 @@ contract TxnGuardMock is ITransactionGuard {
         bytes memory signatures,
         address msgSender
     ) external override {
-        // updates transaction checked
+        // updates the transaction as checked
         preCheckedTransactions = true;
     }
 
@@ -57,7 +57,7 @@ contract TxnGuardMock is ITransactionGuard {
      * @param success The status of the transaction execution.
      */
     function checkAfterExecution(bytes32 hash, bool success) external override {
-        // updates transaction checked
+        // updates the transaction as checked
         postCheckedTransactions = true ;
     }
 

--- a/certora/mocks/TxnGuardMockDuplicate.sol
+++ b/certora/mocks/TxnGuardMockDuplicate.sol
@@ -46,7 +46,7 @@ contract TxnGuardMockDuplicate is ITransactionGuard {
         bytes memory signatures,
         address msgSender
     ) external override {
-        // updates transaction checked
+        // updates the transaction as checked
         preCheckedTransactions = true;
     }
 
@@ -57,7 +57,7 @@ contract TxnGuardMockDuplicate is ITransactionGuard {
      * @param success The status of the transaction execution.
      */
     function checkAfterExecution(bytes32 hash, bool success) external override {
-        // updates transaction checked
+        // updates the transaction as checked
         postCheckedTransactions = true ;
     }
 


### PR DESCRIPTION
updates transaction checked - updates `the` transaction `as` checked

