### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Usage
 ### Install requirements with npm:
 
 ```bash
-npm i
+sudo npm i
 ```
 
 ### Testing


### PR DESCRIPTION
`sudo` is needed because it will try to install `solc` if `solc` is not installed, and it will failed if not `sudo`.


```
Downloading solc 0.7.6
Error HH501: Couldn't download compiler version 0.7.6+commit.7338295f. Please check your internet connection and try again. 
```