### PR TITLE
Fixed typos and grammar issues 

### DIFF
--- a/certora/specs/OwnerReach.spec
+++ b/certora/specs/OwnerReach.spec
@@ -4,7 +4,7 @@
  * This file uses a reach predicate:
  *    ghost reach(address, address) returns bool
  * to represent the transitive relation of the next
- * relation given byt the "owners" field.
+ * relation given by the "owners" field.
  *
  * The idea comes from the paper
  *

--- a/certora/specs/properties.md
+++ b/certora/specs/properties.md
@@ -17,7 +17,7 @@ The categories are based on Certora's workshop [notes](https://github.com/Certor
    The most powerful type of properties covering the entire system. E.g., for any given operation, Safe threshold must remain lower or equal to the number of owners.
 
 5. Unit test
-   Such properties target specific function individually to verify their correctness. E.g., verify that a specific function can only be called by a specific address.
+   Such properties target specific functions individually to verify their correctness. E.g., verify that a specific function can only be called by a specific address.
 
 6. Risk assessment
    Such properties verify that worst cases that can happen to the system are handled correctly. E.g., verify that a transaction cannot be replayed.


### PR DESCRIPTION
1. certora/specs/OwnerReach.spec
byt → by (Fixed typo)
2. certora/specs/properties.md
function → functions (Fixed singular/plural mismatch)