### PR TITLE
Fix links

### DIFF
--- a/docs/safe_tx_gas.md
+++ b/docs/safe_tx_gas.md
@@ -49,7 +49,7 @@ To make it easier to set the `safeTxGas` value a change has been made with the 1
 
 **When `safeTxGas` is set to `0`, the Safe contract will revert if the internal Safe transaction fails** (see [#274](https://github.com/safe-global/safe-smart-account/issues/274))
 
-That means if `safeTxGas` is set to `0` the Safe contract sends along all the available gas when performing the internal Safe transaction. If that transaction fails the Safe will revert and therefore also undo all State changes. This can be seen in [`Safe.sol`](https://github.com/safe-global/safe-smart-account/blob/c85741a6cda020cce3bc523c169909318717736f/contracts/Safe.sol#L179-L186):
+That means if `safeTxGas` is set to `0` the Safe contract sends along all the available gas when performing the internal Safe transaction. If that transaction fails the Safe will revert and therefore also undo all State changes. This can be seen in [`Safe.sol`](https://github.com/safe-global/safe-smart-account/blob/c85741a6cda020cce3bc523c169909318717736f/contracts/Safe.sol#L179-L188):
 
 ```js
 if (!success && safeTxGas == 0 && gasPrice == 0) {

--- a/docs/safe_tx_gas.md
+++ b/docs/safe_tx_gas.md
@@ -10,7 +10,7 @@ The behaviour of `safeTxGas` depends on the `gasPrice` value of the Safe transac
 
 If `gasPrice` is set to a value `>0` the Safe Smart Account will issue a refund for the gas costs incurred during the execution of the Safe transaction. An example where this can be used is the relayers. These would execute the Safe transaction after it has been signed by the owners and then would get refunded for the execution.
 
-The logic for this can be seen in [`Safe.sol`](https://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L183-L185):
+The logic for this can be seen in [`Safe.sol`](https://github.com/safe-global/safe-smart-account/blob/c85741a6cda020cce3bc523c169909318717736f/contracts/Safe.sol#L191-L193):
 
 ```js
 if (gasPrice > 0) {
@@ -30,7 +30,7 @@ If `gasPrice` is set to `0` then the Safe Smart Account will **not** issue a ref
 
 Therefore it is not necessary to be as strict on the gas being passed along with the execution of the Safe transaction. As no refund is triggered the Safe will not pay for the execution costs, based on this the Safe Smart Account will send along all available case when no refund is used.
 
-Before the execution the Safe Smart Account always check if enough gas is available to satisfy the `safeTxGas`. This can be seen in [`Safe.sol`](https://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L168-L170):
+Before the execution the Safe Smart Account always check if enough gas is available to satisfy the `safeTxGas`. This can be seen in [`Safe.sol`](https://github.com/safe-global/safe-smart-account/blob/c85741a6cda020cce3bc523c169909318717736f/contracts/Safe.sol#L168-L169):
 
 ```js
 require(gasleft() >=
@@ -49,7 +49,7 @@ To make it easier to set the `safeTxGas` value a change has been made with the 1
 
 **When `safeTxGas` is set to `0`, the Safe contract will revert if the internal Safe transaction fails** (see [#274](https://github.com/safe-global/safe-smart-account/issues/274))
 
-That means if `safeTxGas` is set to `0` the Safe contract sends along all the available gas when performing the internal Safe transaction. If that transaction fails the Safe will revert and therefore also undo all State changes. This can be seen in [`Safe.sol`](https://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L178-L187):
+That means if `safeTxGas` is set to `0` the Safe contract sends along all the available gas when performing the internal Safe transaction. If that transaction fails the Safe will revert and therefore also undo all State changes. This can be seen in [`Safe.sol`](https://github.com/safe-global/safe-smart-account/blob/c85741a6cda020cce3bc523c169909318717736f/contracts/Safe.sol#L179-L186):
 
 ```js
 if (!success && safeTxGas == 0 && gasPrice == 0) {


### PR DESCRIPTION
The original master file has been changed, and the line numbers referenced by the original URL are no longer accurate. Therefore, a fixed permanent link is used to replace it. The purpose of adopting a permanent link is to prevent the line numbers originally pointed to by the URL from becoming inaccurate again when further changes are made to the master branch.