### PR TITLE
Fix Typographical Error in ModuleReach.spec

### DIFF
--- a/certora/specs/ModuleReach.spec
+++ b/certora/specs/ModuleReach.spec
@@ -4,7 +4,7 @@
  * This file uses a reach predicate:
  *    ghost reach(address, address) returns bool
  * to represent the transitive relation of the next
- * relation given byt the "modules" field.
+ * relation given byte the "modules" field.
  *
  * The idea comes from the paper
  * 


### PR DESCRIPTION
The previous version contained a typo where byt was mistakenly written instead of byte. This change ensures clarity and correctness in the documentation, improving readability and accuracy. The file describes a reach predicate, and correcting the term byte makes it more comprehensible for developers referencing this documentation.