### PR TITLE
Update Transitive Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.cache/
 build/
 node_modules/
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "eslint-plugin-no-only-tests": "^3.3.0",
                 "eslint-plugin-prettier": "^5.2.6",
                 "hardhat": "^2.22.19",
-                "hardhat-deploy": "^0.12.4",
+                "hardhat-deploy": "^1.0.2",
                 "husky": "^9.1.7",
                 "prettier": "^3.5.3",
                 "prettier-plugin-solidity": "^1.4.2",
@@ -100,9 +100,9 @@
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-            "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
+            "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -358,9 +358,9 @@
             }
         },
         "node_modules/@ethersproject/abi": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
-            "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.8.0.tgz",
+            "integrity": "sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==",
             "dev": true,
             "funding": [
                 {
@@ -374,21 +374,45 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/address": "^5.7.0",
-                "@ethersproject/bignumber": "^5.7.0",
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/constants": "^5.7.0",
-                "@ethersproject/hash": "^5.7.0",
-                "@ethersproject/keccak256": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0",
-                "@ethersproject/properties": "^5.7.0",
-                "@ethersproject/strings": "^5.7.0"
+                "@ethersproject/address": "^5.8.0",
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/constants": "^5.8.0",
+                "@ethersproject/hash": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/strings": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/abi/node_modules/@ethersproject/address": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+            "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/rlp": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/abstract-provider": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
-            "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz",
+            "integrity": "sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==",
             "dev": true,
             "funding": [
                 {
@@ -402,19 +426,19 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/bignumber": "^5.7.0",
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0",
-                "@ethersproject/networks": "^5.7.0",
-                "@ethersproject/properties": "^5.7.0",
-                "@ethersproject/transactions": "^5.7.0",
-                "@ethersproject/web": "^5.7.0"
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/networks": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/transactions": "^5.8.0",
+                "@ethersproject/web": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/abstract-signer": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
-            "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz",
+            "integrity": "sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==",
             "dev": true,
             "funding": [
                 {
@@ -428,11 +452,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/abstract-provider": "^5.7.0",
-                "@ethersproject/bignumber": "^5.7.0",
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0",
-                "@ethersproject/properties": "^5.7.0"
+                "@ethersproject/abstract-provider": "^5.8.0",
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/address": {
@@ -460,9 +484,9 @@
             }
         },
         "node_modules/@ethersproject/base64": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
-            "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.8.0.tgz",
+            "integrity": "sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==",
             "dev": true,
             "funding": [
                 {
@@ -476,13 +500,13 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/bytes": "^5.7.0"
+                "@ethersproject/bytes": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/basex": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
-            "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.8.0.tgz",
+            "integrity": "sha512-PIgTszMlDRmNwW9nhS6iqtVfdTAKosA7llYXNmGPw4YAI1PUyMv28988wAb41/gHF/WqGdoLv0erHaRcHRKW2Q==",
             "dev": true,
             "funding": [
                 {
@@ -496,14 +520,14 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/properties": "^5.7.0"
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/bignumber": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
-            "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.8.0.tgz",
+            "integrity": "sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==",
             "dev": true,
             "funding": [
                 {
@@ -517,15 +541,15 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
                 "bn.js": "^5.2.1"
             }
         },
         "node_modules/@ethersproject/bytes": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
-            "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.8.0.tgz",
+            "integrity": "sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==",
             "dev": true,
             "funding": [
                 {
@@ -539,13 +563,13 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/logger": "^5.7.0"
+                "@ethersproject/logger": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/constants": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
-            "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.8.0.tgz",
+            "integrity": "sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==",
             "dev": true,
             "funding": [
                 {
@@ -559,13 +583,13 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/bignumber": "^5.7.0"
+                "@ethersproject/bignumber": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/contracts": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
-            "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.8.0.tgz",
+            "integrity": "sha512-0eFjGz9GtuAi6MZwhb4uvUM216F38xiuR0yYCjKJpNfSEy4HUM8hvqqBj9Jmm0IUz8l0xKEhWwLIhPgxNY0yvQ==",
             "dev": true,
             "funding": [
                 {
@@ -579,22 +603,46 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/abi": "^5.7.0",
-                "@ethersproject/abstract-provider": "^5.7.0",
-                "@ethersproject/abstract-signer": "^5.7.0",
-                "@ethersproject/address": "^5.7.0",
-                "@ethersproject/bignumber": "^5.7.0",
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/constants": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0",
-                "@ethersproject/properties": "^5.7.0",
-                "@ethersproject/transactions": "^5.7.0"
+                "@ethersproject/abi": "^5.8.0",
+                "@ethersproject/abstract-provider": "^5.8.0",
+                "@ethersproject/abstract-signer": "^5.8.0",
+                "@ethersproject/address": "^5.8.0",
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/constants": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/transactions": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/contracts/node_modules/@ethersproject/address": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+            "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/rlp": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/hash": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
-            "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.8.0.tgz",
+            "integrity": "sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==",
             "dev": true,
             "funding": [
                 {
@@ -608,21 +656,45 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/abstract-signer": "^5.7.0",
-                "@ethersproject/address": "^5.7.0",
-                "@ethersproject/base64": "^5.7.0",
-                "@ethersproject/bignumber": "^5.7.0",
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/keccak256": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0",
-                "@ethersproject/properties": "^5.7.0",
-                "@ethersproject/strings": "^5.7.0"
+                "@ethersproject/abstract-signer": "^5.8.0",
+                "@ethersproject/address": "^5.8.0",
+                "@ethersproject/base64": "^5.8.0",
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/strings": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/hash/node_modules/@ethersproject/address": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+            "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/rlp": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/hdnode": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
-            "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.8.0.tgz",
+            "integrity": "sha512-4bK1VF6E83/3/Im0ERnnUeWOY3P1BZml4ZD3wcH8Ys0/d1h1xaFt6Zc+Dh9zXf9TapGro0T4wvO71UTCp3/uoA==",
             "dev": true,
             "funding": [
                 {
@@ -636,24 +708,24 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/abstract-signer": "^5.7.0",
-                "@ethersproject/basex": "^5.7.0",
-                "@ethersproject/bignumber": "^5.7.0",
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0",
-                "@ethersproject/pbkdf2": "^5.7.0",
-                "@ethersproject/properties": "^5.7.0",
-                "@ethersproject/sha2": "^5.7.0",
-                "@ethersproject/signing-key": "^5.7.0",
-                "@ethersproject/strings": "^5.7.0",
-                "@ethersproject/transactions": "^5.7.0",
-                "@ethersproject/wordlists": "^5.7.0"
+                "@ethersproject/abstract-signer": "^5.8.0",
+                "@ethersproject/basex": "^5.8.0",
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/pbkdf2": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/sha2": "^5.8.0",
+                "@ethersproject/signing-key": "^5.8.0",
+                "@ethersproject/strings": "^5.8.0",
+                "@ethersproject/transactions": "^5.8.0",
+                "@ethersproject/wordlists": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/json-wallets": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
-            "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.8.0.tgz",
+            "integrity": "sha512-HxblNck8FVUtNxS3VTEYJAcwiKYsBIF77W15HufqlBF9gGfhmYOJtYZp8fSDZtn9y5EaXTE87zDwzxRoTFk11w==",
             "dev": true,
             "funding": [
                 {
@@ -667,19 +739,43 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/abstract-signer": "^5.7.0",
-                "@ethersproject/address": "^5.7.0",
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/hdnode": "^5.7.0",
-                "@ethersproject/keccak256": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0",
-                "@ethersproject/pbkdf2": "^5.7.0",
-                "@ethersproject/properties": "^5.7.0",
-                "@ethersproject/random": "^5.7.0",
-                "@ethersproject/strings": "^5.7.0",
-                "@ethersproject/transactions": "^5.7.0",
+                "@ethersproject/abstract-signer": "^5.8.0",
+                "@ethersproject/address": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/hdnode": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/pbkdf2": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/random": "^5.8.0",
+                "@ethersproject/strings": "^5.8.0",
+                "@ethersproject/transactions": "^5.8.0",
                 "aes-js": "3.0.0",
                 "scrypt-js": "3.0.1"
+            }
+        },
+        "node_modules/@ethersproject/json-wallets/node_modules/@ethersproject/address": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+            "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/rlp": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/json-wallets/node_modules/aes-js": {
@@ -690,9 +786,9 @@
             "license": "MIT"
         },
         "node_modules/@ethersproject/keccak256": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
-            "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.8.0.tgz",
+            "integrity": "sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==",
             "dev": true,
             "funding": [
                 {
@@ -706,14 +802,14 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/bytes": "^5.8.0",
                 "js-sha3": "0.8.0"
             }
         },
         "node_modules/@ethersproject/logger": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
-            "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.8.0.tgz",
+            "integrity": "sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==",
             "dev": true,
             "funding": [
                 {
@@ -728,9 +824,9 @@
             "license": "MIT"
         },
         "node_modules/@ethersproject/networks": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
-            "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.8.0.tgz",
+            "integrity": "sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==",
             "dev": true,
             "funding": [
                 {
@@ -744,13 +840,13 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/logger": "^5.7.0"
+                "@ethersproject/logger": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/pbkdf2": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
-            "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.8.0.tgz",
+            "integrity": "sha512-wuHiv97BrzCmfEaPbUFpMjlVg/IDkZThp9Ri88BpjRleg4iePJaj2SW8AIyE8cXn5V1tuAaMj6lzvsGJkGWskg==",
             "dev": true,
             "funding": [
                 {
@@ -764,14 +860,14 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/sha2": "^5.7.0"
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/sha2": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/properties": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
-            "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz",
+            "integrity": "sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==",
             "dev": true,
             "funding": [
                 {
@@ -785,13 +881,13 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/logger": "^5.7.0"
+                "@ethersproject/logger": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/providers": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
-            "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.8.0.tgz",
+            "integrity": "sha512-3Il3oTzEx3o6kzcg9ZzbE+oCZYyY+3Zh83sKkn4s1DZfTUjIegHnN2Cm0kbn9YFy45FDVcuCLLONhU7ny0SsCw==",
             "dev": true,
             "funding": [
                 {
@@ -805,40 +901,64 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/abstract-provider": "^5.7.0",
-                "@ethersproject/abstract-signer": "^5.7.0",
-                "@ethersproject/address": "^5.7.0",
-                "@ethersproject/base64": "^5.7.0",
-                "@ethersproject/basex": "^5.7.0",
-                "@ethersproject/bignumber": "^5.7.0",
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/constants": "^5.7.0",
-                "@ethersproject/hash": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0",
-                "@ethersproject/networks": "^5.7.0",
-                "@ethersproject/properties": "^5.7.0",
-                "@ethersproject/random": "^5.7.0",
-                "@ethersproject/rlp": "^5.7.0",
-                "@ethersproject/sha2": "^5.7.0",
-                "@ethersproject/strings": "^5.7.0",
-                "@ethersproject/transactions": "^5.7.0",
-                "@ethersproject/web": "^5.7.0",
+                "@ethersproject/abstract-provider": "^5.8.0",
+                "@ethersproject/abstract-signer": "^5.8.0",
+                "@ethersproject/address": "^5.8.0",
+                "@ethersproject/base64": "^5.8.0",
+                "@ethersproject/basex": "^5.8.0",
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/constants": "^5.8.0",
+                "@ethersproject/hash": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/networks": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/random": "^5.8.0",
+                "@ethersproject/rlp": "^5.8.0",
+                "@ethersproject/sha2": "^5.8.0",
+                "@ethersproject/strings": "^5.8.0",
+                "@ethersproject/transactions": "^5.8.0",
+                "@ethersproject/web": "^5.8.0",
                 "bech32": "1.1.4",
-                "ws": "7.4.6"
+                "ws": "8.18.0"
+            }
+        },
+        "node_modules/@ethersproject/providers/node_modules/@ethersproject/address": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+            "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/rlp": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/providers/node_modules/ws": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-            "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=8.3.0"
+                "node": ">=10.0.0"
             },
             "peerDependencies": {
                 "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
+                "utf-8-validate": ">=5.0.2"
             },
             "peerDependenciesMeta": {
                 "bufferutil": {
@@ -850,9 +970,9 @@
             }
         },
         "node_modules/@ethersproject/random": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
-            "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.8.0.tgz",
+            "integrity": "sha512-E4I5TDl7SVqyg4/kkA/qTfuLWAQGXmSOgYyO01So8hLfwgKvYK5snIlzxJMk72IFdG/7oh8yuSqY2KX7MMwg+A==",
             "dev": true,
             "funding": [
                 {
@@ -866,14 +986,14 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0"
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/rlp": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
-            "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.8.0.tgz",
+            "integrity": "sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==",
             "dev": true,
             "funding": [
                 {
@@ -887,14 +1007,14 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0"
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/sha2": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
-            "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.8.0.tgz",
+            "integrity": "sha512-dDOUrXr9wF/YFltgTBYS0tKslPEKr6AekjqDW2dbn1L1xmjGR+9GiKu4ajxovnrDbwxAKdHjW8jNcwfz8PAz4A==",
             "dev": true,
             "funding": [
                 {
@@ -908,15 +1028,15 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
                 "hash.js": "1.1.7"
             }
         },
         "node_modules/@ethersproject/signing-key": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
-            "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.8.0.tgz",
+            "integrity": "sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==",
             "dev": true,
             "funding": [
                 {
@@ -930,18 +1050,18 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0",
-                "@ethersproject/properties": "^5.7.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
                 "bn.js": "^5.2.1",
-                "elliptic": "6.5.4",
+                "elliptic": "6.6.1",
                 "hash.js": "1.1.7"
             }
         },
         "node_modules/@ethersproject/solidity": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
-            "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.8.0.tgz",
+            "integrity": "sha512-4CxFeCgmIWamOHwYN9d+QWGxye9qQLilpgTU0XhYs1OahkclF+ewO+3V1U0mvpiuQxm5EHHmv8f7ClVII8EHsA==",
             "dev": true,
             "funding": [
                 {
@@ -955,18 +1075,18 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/bignumber": "^5.7.0",
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/keccak256": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0",
-                "@ethersproject/sha2": "^5.7.0",
-                "@ethersproject/strings": "^5.7.0"
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/sha2": "^5.8.0",
+                "@ethersproject/strings": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/strings": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
-            "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.8.0.tgz",
+            "integrity": "sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==",
             "dev": true,
             "funding": [
                 {
@@ -980,15 +1100,15 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/constants": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0"
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/constants": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/transactions": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
-            "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.8.0.tgz",
+            "integrity": "sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==",
             "dev": true,
             "funding": [
                 {
@@ -1002,21 +1122,45 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/address": "^5.7.0",
-                "@ethersproject/bignumber": "^5.7.0",
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/constants": "^5.7.0",
-                "@ethersproject/keccak256": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0",
-                "@ethersproject/properties": "^5.7.0",
-                "@ethersproject/rlp": "^5.7.0",
-                "@ethersproject/signing-key": "^5.7.0"
+                "@ethersproject/address": "^5.8.0",
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/constants": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/rlp": "^5.8.0",
+                "@ethersproject/signing-key": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/transactions/node_modules/@ethersproject/address": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+            "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/rlp": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/units": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
-            "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.8.0.tgz",
+            "integrity": "sha512-lxq0CAnc5kMGIiWW4Mr041VT8IhNM+Pn5T3haO74XZWFulk7wH1Gv64HqE96hT4a7iiNMdOCFEBgaxWuk8ETKQ==",
             "dev": true,
             "funding": [
                 {
@@ -1030,15 +1174,15 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/bignumber": "^5.7.0",
-                "@ethersproject/constants": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0"
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/constants": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/wallet": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
-            "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.8.0.tgz",
+            "integrity": "sha512-G+jnzmgg6UxurVKRKvw27h0kvG75YKXZKdlLYmAHeF32TGUzHkOFd7Zn6QHOTYRFWnfjtSSFjBowKo7vfrXzPA==",
             "dev": true,
             "funding": [
                 {
@@ -1052,27 +1196,51 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/abstract-provider": "^5.7.0",
-                "@ethersproject/abstract-signer": "^5.7.0",
-                "@ethersproject/address": "^5.7.0",
-                "@ethersproject/bignumber": "^5.7.0",
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/hash": "^5.7.0",
-                "@ethersproject/hdnode": "^5.7.0",
-                "@ethersproject/json-wallets": "^5.7.0",
-                "@ethersproject/keccak256": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0",
-                "@ethersproject/properties": "^5.7.0",
-                "@ethersproject/random": "^5.7.0",
-                "@ethersproject/signing-key": "^5.7.0",
-                "@ethersproject/transactions": "^5.7.0",
-                "@ethersproject/wordlists": "^5.7.0"
+                "@ethersproject/abstract-provider": "^5.8.0",
+                "@ethersproject/abstract-signer": "^5.8.0",
+                "@ethersproject/address": "^5.8.0",
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/hash": "^5.8.0",
+                "@ethersproject/hdnode": "^5.8.0",
+                "@ethersproject/json-wallets": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/random": "^5.8.0",
+                "@ethersproject/signing-key": "^5.8.0",
+                "@ethersproject/transactions": "^5.8.0",
+                "@ethersproject/wordlists": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/wallet/node_modules/@ethersproject/address": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+            "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/rlp": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/web": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
-            "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.8.0.tgz",
+            "integrity": "sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==",
             "dev": true,
             "funding": [
                 {
@@ -1086,17 +1254,17 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/base64": "^5.7.0",
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0",
-                "@ethersproject/properties": "^5.7.0",
-                "@ethersproject/strings": "^5.7.0"
+                "@ethersproject/base64": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/strings": "^5.8.0"
             }
         },
         "node_modules/@ethersproject/wordlists": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
-            "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.8.0.tgz",
+            "integrity": "sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg==",
             "dev": true,
             "funding": [
                 {
@@ -1110,11 +1278,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@ethersproject/bytes": "^5.7.0",
-                "@ethersproject/hash": "^5.7.0",
-                "@ethersproject/logger": "^5.7.0",
-                "@ethersproject/properties": "^5.7.0",
-                "@ethersproject/strings": "^5.7.0"
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/hash": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/strings": "^5.8.0"
             }
         },
         "node_modules/@fastify/busboy": {
@@ -1128,9 +1296,9 @@
             }
         },
         "node_modules/@grpc/grpc-js": {
-            "version": "1.12.5",
-            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.5.tgz",
-            "integrity": "sha512-d3iiHxdpg5+ZcJ6jnDSOT8Z0O0VMVGy34jAnYLUX8yd36b1qn8f1TwOA/Lc7TsOh03IkPJ38eGI5qD2EjNkoEA==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.2.tgz",
+            "integrity": "sha512-nnR5nmL6lxF8YBqb6gWvEgLdLh/Fn+kvAdX5hUOnt48sNSb0riz/93ASd2E5gvanPA41X6Yp25bIfGRp1SMb2g==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -1504,7 +1672,7 @@
             "name": "zksync-telemetry",
             "version": "1.0.0",
             "resolved": "git+ssh://git@github.com/matter-labs/zksync-telemetry-js.git#2fd9edbe6b9a5e0c2caeda4b04dd5631d7546a11",
-            "integrity": "sha512-2RfFYmhth0KYSn3MKHzGZxlP0HtCgQe4JeREfBaVPfqNifOweyy0L66BEyptew7Eu5N3Bdi5IfRRRctcVy1f/w==",
+            "integrity": "sha512-BBbpABVl6taa5Q1imJtwv0NPki3foWeJVrKAlgQlHxEHk2N7w7qpwqfkKX6+3soHWrm/xQK2y28B6vMERWR83Q==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1513,77 +1681,6 @@
                 "posthog-node": "^4.10.1",
                 "readline-sync": "^1.4.10",
                 "uuid": "^11.0.3"
-            }
-        },
-        "node_modules/@matterlabs/zksync-telemetry-js/node_modules/@sentry/core": {
-            "version": "8.55.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.0.tgz",
-            "integrity": "sha512-6g7jpbefjHYs821Z+EBJ8r4Z7LT5h80YSWRJaylGS4nW5W5Z2KXzpdnyFarv37O7QjauzVC2E+PABmpkw5/JGA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.18"
-            }
-        },
-        "node_modules/@matterlabs/zksync-telemetry-js/node_modules/@sentry/node": {
-            "version": "8.55.0",
-            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-8.55.0.tgz",
-            "integrity": "sha512-h10LJLDTRAzYgay60Oy7moMookqqSZSviCWkkmHZyaDn+4WURnPp5SKhhfrzPRQcXKrweiOwDSHBgn1tweDssg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@opentelemetry/api": "^1.9.0",
-                "@opentelemetry/context-async-hooks": "^1.30.1",
-                "@opentelemetry/core": "^1.30.1",
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/instrumentation-amqplib": "^0.46.0",
-                "@opentelemetry/instrumentation-connect": "0.43.0",
-                "@opentelemetry/instrumentation-dataloader": "0.16.0",
-                "@opentelemetry/instrumentation-express": "0.47.0",
-                "@opentelemetry/instrumentation-fastify": "0.44.1",
-                "@opentelemetry/instrumentation-fs": "0.19.0",
-                "@opentelemetry/instrumentation-generic-pool": "0.43.0",
-                "@opentelemetry/instrumentation-graphql": "0.47.0",
-                "@opentelemetry/instrumentation-hapi": "0.45.1",
-                "@opentelemetry/instrumentation-http": "0.57.1",
-                "@opentelemetry/instrumentation-ioredis": "0.47.0",
-                "@opentelemetry/instrumentation-kafkajs": "0.7.0",
-                "@opentelemetry/instrumentation-knex": "0.44.0",
-                "@opentelemetry/instrumentation-koa": "0.47.0",
-                "@opentelemetry/instrumentation-lru-memoizer": "0.44.0",
-                "@opentelemetry/instrumentation-mongodb": "0.51.0",
-                "@opentelemetry/instrumentation-mongoose": "0.46.0",
-                "@opentelemetry/instrumentation-mysql": "0.45.0",
-                "@opentelemetry/instrumentation-mysql2": "0.45.0",
-                "@opentelemetry/instrumentation-nestjs-core": "0.44.0",
-                "@opentelemetry/instrumentation-pg": "0.50.0",
-                "@opentelemetry/instrumentation-redis-4": "0.46.0",
-                "@opentelemetry/instrumentation-tedious": "0.18.0",
-                "@opentelemetry/instrumentation-undici": "0.10.0",
-                "@opentelemetry/resources": "^1.30.1",
-                "@opentelemetry/sdk-trace-base": "^1.30.1",
-                "@opentelemetry/semantic-conventions": "^1.28.0",
-                "@prisma/instrumentation": "5.22.0",
-                "@sentry/core": "8.55.0",
-                "@sentry/opentelemetry": "8.55.0",
-                "import-in-the-middle": "^1.11.2"
-            },
-            "engines": {
-                "node": ">=14.18"
-            }
-        },
-        "node_modules/@matterlabs/zksync-telemetry-js/node_modules/uuid": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-            "dev": true,
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/@metamask/eth-sig-util": {
@@ -1909,15 +2006,15 @@
             }
         },
         "node_modules/@nomicfoundation/hardhat-ignition": {
-            "version": "0.15.9",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition/-/hardhat-ignition-0.15.9.tgz",
-            "integrity": "sha512-lSWqhaDOBt6gsqMadkRLvH6HdoFV1v8/bx7z+12cghaOloVwwn48CPoTH2iXXnkqilPGw8rdH5eVTE6UM+2v6Q==",
+            "version": "0.15.10",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition/-/hardhat-ignition-0.15.10.tgz",
+            "integrity": "sha512-UScXyLLG5rEm+ANchQYCDOsskdXl6ux3oCPgC24PKE/QMJEib5crGZIo8spAyzdK6vOnRW6i4FG+1qvoO0AGWA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@nomicfoundation/ignition-core": "^0.15.9",
-                "@nomicfoundation/ignition-ui": "^0.15.9",
+                "@nomicfoundation/ignition-core": "^0.15.10",
+                "@nomicfoundation/ignition-ui": "^0.15.10",
                 "chalk": "^4.0.0",
                 "debug": "^4.3.2",
                 "fs-extra": "^10.0.0",
@@ -1930,16 +2027,16 @@
             }
         },
         "node_modules/@nomicfoundation/hardhat-ignition-ethers": {
-            "version": "0.15.9",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition-ethers/-/hardhat-ignition-ethers-0.15.9.tgz",
-            "integrity": "sha512-9PwwgLv3z2ec3B26mK0IjiFezHFFBcBcs1qKaRu8SanARE4b7RvrfiLIy8ZXE7HaxgPt32kSsQzehhzAwAIj1Q==",
+            "version": "0.15.10",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition-ethers/-/hardhat-ignition-ethers-0.15.10.tgz",
+            "integrity": "sha512-P90glRiBbR4mnMKP/LePovfUJjYT2YWJjx7118i7yxssUwcaW9wFohb4bFh+236N1tqM4q7aGx9cBvHNgve3zA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "peerDependencies": {
                 "@nomicfoundation/hardhat-ethers": "^3.0.4",
-                "@nomicfoundation/hardhat-ignition": "^0.15.9",
-                "@nomicfoundation/ignition-core": "^0.15.9",
+                "@nomicfoundation/hardhat-ignition": "^0.15.10",
+                "@nomicfoundation/ignition-core": "^0.15.10",
                 "ethers": "^6.7.0",
                 "hardhat": "^2.18.0"
             }
@@ -2002,9 +2099,9 @@
             }
         },
         "node_modules/@nomicfoundation/hardhat-verify": {
-            "version": "2.0.12",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.12.tgz",
-            "integrity": "sha512-Lg3Nu7DCXASQRVI/YysjuAX2z8jwOCbS0w5tz2HalWGSTZThqA0v9N0v0psHbKNqzPJa8bNOeapIVSziyJTnAg==",
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.13.tgz",
+            "integrity": "sha512-i57GX1sC0kYGyRVnbQrjjyBTpWTKgrvKC+jH8CMKV6gHp959Upb8lKaZ58WRHIU0espkulTxLnacYeUDirwJ2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2046,9 +2143,9 @@
             }
         },
         "node_modules/@nomicfoundation/hardhat-verify/node_modules/undici": {
-            "version": "5.28.5",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
-            "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2059,9 +2156,9 @@
             }
         },
         "node_modules/@nomicfoundation/ignition-core": {
-            "version": "0.15.9",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-core/-/ignition-core-0.15.9.tgz",
-            "integrity": "sha512-X8W+7UP/UQPorpHUnGvA1OdsEr/edGi8tDpNwEqzaLm83FMZVbRWdOsr3vNICHN2XMzNY/xIm18Cx7xGKL2PQw==",
+            "version": "0.15.10",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-core/-/ignition-core-0.15.10.tgz",
+            "integrity": "sha512-AWvCviNlBkPT8EKcg34N+yUdQTYFiC/HdpfFZdw8oMFuAs9SMZE0zQA9gJQSCay41GbuyXt2Kietp5/1/nlBIA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -2119,9 +2216,9 @@
             }
         },
         "node_modules/@nomicfoundation/ignition-ui": {
-            "version": "0.15.9",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-0.15.9.tgz",
-            "integrity": "sha512-8lzbT7gpJ5PoowPQDQilkwdyqBviUKDMoHp/5rhgnwG1bDslnCS+Lxuo6s9R2akWu9LtEL14dNyqQb6WsURTag==",
+            "version": "0.15.10",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-0.15.10.tgz",
+            "integrity": "sha512-82XQPF+1fvxTimDUPgDVwpTjHjfjFgFs84rERbBiMLQbz6sPtgTlV8HHrlbMx8tT/JKCI/SCU4gxV8xA4CPfcg==",
             "dev": true,
             "peer": true
         },
@@ -2382,9 +2479,9 @@
             "license": "MIT"
         },
         "node_modules/@nomiclabs/hardhat-docker/node_modules/tar-fs": {
-            "version": "1.16.3",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-            "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+            "version": "1.16.4",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.4.tgz",
+            "integrity": "sha512-u3XczWoYAIVXe5GOKK6+VeWaHjtc47W7hyuTo3+4cNakcCcuDmlkYiiHEsECwTkcI3h1VUgtwBQ54+RvY6cM4w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3402,28 +3499,14 @@
             }
         },
         "node_modules/@sentry/core": {
-            "version": "5.30.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
-            "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
+            "version": "8.55.0",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.0.tgz",
+            "integrity": "sha512-6g7jpbefjHYs821Z+EBJ8r4Z7LT5h80YSWRJaylGS4nW5W5Z2KXzpdnyFarv37O7QjauzVC2E+PABmpkw5/JGA==",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@sentry/hub": "5.30.0",
-                "@sentry/minimal": "5.30.0",
-                "@sentry/types": "5.30.0",
-                "@sentry/utils": "5.30.0",
-                "tslib": "^1.9.3"
-            },
+            "license": "MIT",
             "engines": {
-                "node": ">=6"
+                "node": ">=14.18"
             }
-        },
-        "node_modules/@sentry/core/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true,
-            "license": "0BSD"
         },
         "node_modules/@sentry/hub": {
             "version": "5.30.0",
@@ -3470,32 +3553,51 @@
             "license": "0BSD"
         },
         "node_modules/@sentry/node": {
-            "version": "5.30.0",
-            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.30.0.tgz",
-            "integrity": "sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==",
+            "version": "8.55.0",
+            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-8.55.0.tgz",
+            "integrity": "sha512-h10LJLDTRAzYgay60Oy7moMookqqSZSviCWkkmHZyaDn+4WURnPp5SKhhfrzPRQcXKrweiOwDSHBgn1tweDssg==",
             "dev": true,
-            "license": "BSD-3-Clause",
+            "license": "MIT",
             "dependencies": {
-                "@sentry/core": "5.30.0",
-                "@sentry/hub": "5.30.0",
-                "@sentry/tracing": "5.30.0",
-                "@sentry/types": "5.30.0",
-                "@sentry/utils": "5.30.0",
-                "cookie": "^0.4.1",
-                "https-proxy-agent": "^5.0.0",
-                "lru_map": "^0.3.3",
-                "tslib": "^1.9.3"
+                "@opentelemetry/api": "^1.9.0",
+                "@opentelemetry/context-async-hooks": "^1.30.1",
+                "@opentelemetry/core": "^1.30.1",
+                "@opentelemetry/instrumentation": "^0.57.1",
+                "@opentelemetry/instrumentation-amqplib": "^0.46.0",
+                "@opentelemetry/instrumentation-connect": "0.43.0",
+                "@opentelemetry/instrumentation-dataloader": "0.16.0",
+                "@opentelemetry/instrumentation-express": "0.47.0",
+                "@opentelemetry/instrumentation-fastify": "0.44.1",
+                "@opentelemetry/instrumentation-fs": "0.19.0",
+                "@opentelemetry/instrumentation-generic-pool": "0.43.0",
+                "@opentelemetry/instrumentation-graphql": "0.47.0",
+                "@opentelemetry/instrumentation-hapi": "0.45.1",
+                "@opentelemetry/instrumentation-http": "0.57.1",
+                "@opentelemetry/instrumentation-ioredis": "0.47.0",
+                "@opentelemetry/instrumentation-kafkajs": "0.7.0",
+                "@opentelemetry/instrumentation-knex": "0.44.0",
+                "@opentelemetry/instrumentation-koa": "0.47.0",
+                "@opentelemetry/instrumentation-lru-memoizer": "0.44.0",
+                "@opentelemetry/instrumentation-mongodb": "0.51.0",
+                "@opentelemetry/instrumentation-mongoose": "0.46.0",
+                "@opentelemetry/instrumentation-mysql": "0.45.0",
+                "@opentelemetry/instrumentation-mysql2": "0.45.0",
+                "@opentelemetry/instrumentation-nestjs-core": "0.44.0",
+                "@opentelemetry/instrumentation-pg": "0.50.0",
+                "@opentelemetry/instrumentation-redis-4": "0.46.0",
+                "@opentelemetry/instrumentation-tedious": "0.18.0",
+                "@opentelemetry/instrumentation-undici": "0.10.0",
+                "@opentelemetry/resources": "^1.30.1",
+                "@opentelemetry/sdk-trace-base": "^1.30.1",
+                "@opentelemetry/semantic-conventions": "^1.28.0",
+                "@prisma/instrumentation": "5.22.0",
+                "@sentry/core": "8.55.0",
+                "@sentry/opentelemetry": "8.55.0",
+                "import-in-the-middle": "^1.11.2"
             },
             "engines": {
-                "node": ">=6"
+                "node": ">=14.18"
             }
-        },
-        "node_modules/@sentry/node/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true,
-            "license": "0BSD"
         },
         "node_modules/@sentry/opentelemetry": {
             "version": "8.55.0",
@@ -3516,16 +3618,6 @@
                 "@opentelemetry/instrumentation": "^0.57.1",
                 "@opentelemetry/sdk-trace-base": "^1.30.1",
                 "@opentelemetry/semantic-conventions": "^1.28.0"
-            }
-        },
-        "node_modules/@sentry/opentelemetry/node_modules/@sentry/core": {
-            "version": "8.55.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.0.tgz",
-            "integrity": "sha512-6g7jpbefjHYs821Z+EBJ8r4Z7LT5h80YSWRJaylGS4nW5W5Z2KXzpdnyFarv37O7QjauzVC2E+PABmpkw5/JGA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.18"
             }
         },
         "node_modules/@sentry/tracing": {
@@ -3827,9 +3919,9 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+            "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -3903,9 +3995,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "20.17.12",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.12.tgz",
-            "integrity": "sha512-vo/wmBgMIiEA23A/knMfn/cf37VnuF52nZh5ZoW0GWt4e4sxNquibrMRJ7UQsA06+MBx9r/H1jsI9grYjQCQlw==",
+            "version": "20.17.30",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
+            "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3953,9 +4045,9 @@
             "peer": true
         },
         "node_modules/@types/qs": {
-            "version": "6.9.17",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.17.tgz",
-            "integrity": "sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==",
+            "version": "6.9.18",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+            "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
             "dev": true,
             "license": "MIT"
         },
@@ -4205,9 +4297,9 @@
             "peer": true
         },
         "node_modules/acorn": {
-            "version": "8.14.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-            "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+            "version": "8.14.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+            "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -4556,9 +4648,9 @@
             "license": "MIT"
         },
         "node_modules/base-x": {
-            "version": "3.0.10",
-            "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
-            "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+            "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4873,9 +4965,9 @@
             }
         },
         "node_modules/call-bind-apply-helpers": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
-            "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4887,14 +4979,14 @@
             }
         },
         "node_modules/call-bound": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-            "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "get-intrinsic": "^1.2.6"
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -5745,9 +5837,9 @@
             }
         },
         "node_modules/docker-modem": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.5.tgz",
-            "integrity": "sha512-Cxw8uEcvNTRmsQuGqzzfiCnfGgf96tVJItLh8taOX0miTcIBALKH5TckCSuZbpbjP7uhAl81dOL9sxfa6HgCIg==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.6.tgz",
+            "integrity": "sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -5761,22 +5853,36 @@
             }
         },
         "node_modules/dockerode": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.3.tgz",
-            "integrity": "sha512-QSXJFcBQNaGZO6U3qWW4B7p8yRIJn/dWmvL2AQWfO/bjptBBO6QYdVkYSYFz9qoivP2jsOHZfmXMAfrK0BMKyg==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.5.tgz",
+            "integrity": "sha512-ZPmKSr1k1571Mrh7oIBS/j0AqAccoecY2yH420ni5j1KyNMgnoTh4Nu4FWunh0HZIJmRSmSysJjBIpa/zyWUEA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@balena/dockerignore": "^1.0.2",
                 "@grpc/grpc-js": "^1.11.1",
                 "@grpc/proto-loader": "^0.7.13",
-                "docker-modem": "^5.0.5",
+                "docker-modem": "^5.0.6",
                 "protobufjs": "^7.3.2",
-                "tar-fs": "~2.0.1",
+                "tar-fs": "~2.1.2",
                 "uuid": "^10.0.0"
             },
             "engines": {
                 "node": ">= 8.0"
+            }
+        },
+        "node_modules/dockerode/node_modules/uuid": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+            "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/dotenv": {
@@ -5815,9 +5921,9 @@
             "license": "MIT"
         },
         "node_modules/elliptic": {
-            "version": "6.5.4",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+            "version": "6.6.1",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+            "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5916,13 +6022,29 @@
             }
         },
         "node_modules/es-object-atoms": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-            "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6348,6 +6470,31 @@
                 }
             }
         },
+        "node_modules/eth-gas-reporter/node_modules/@ethersproject/address": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+            "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/rlp": "^5.8.0"
+            }
+        },
         "node_modules/eth-gas-reporter/node_modules/@noble/hashes": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
@@ -6414,9 +6561,9 @@
             }
         },
         "node_modules/eth-gas-reporter/node_modules/ethers": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-            "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.8.0.tgz",
+            "integrity": "sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==",
             "dev": true,
             "funding": [
                 {
@@ -6431,36 +6578,36 @@
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@ethersproject/abi": "5.7.0",
-                "@ethersproject/abstract-provider": "5.7.0",
-                "@ethersproject/abstract-signer": "5.7.0",
-                "@ethersproject/address": "5.7.0",
-                "@ethersproject/base64": "5.7.0",
-                "@ethersproject/basex": "5.7.0",
-                "@ethersproject/bignumber": "5.7.0",
-                "@ethersproject/bytes": "5.7.0",
-                "@ethersproject/constants": "5.7.0",
-                "@ethersproject/contracts": "5.7.0",
-                "@ethersproject/hash": "5.7.0",
-                "@ethersproject/hdnode": "5.7.0",
-                "@ethersproject/json-wallets": "5.7.0",
-                "@ethersproject/keccak256": "5.7.0",
-                "@ethersproject/logger": "5.7.0",
-                "@ethersproject/networks": "5.7.1",
-                "@ethersproject/pbkdf2": "5.7.0",
-                "@ethersproject/properties": "5.7.0",
-                "@ethersproject/providers": "5.7.2",
-                "@ethersproject/random": "5.7.0",
-                "@ethersproject/rlp": "5.7.0",
-                "@ethersproject/sha2": "5.7.0",
-                "@ethersproject/signing-key": "5.7.0",
-                "@ethersproject/solidity": "5.7.0",
-                "@ethersproject/strings": "5.7.0",
-                "@ethersproject/transactions": "5.7.0",
-                "@ethersproject/units": "5.7.0",
-                "@ethersproject/wallet": "5.7.0",
-                "@ethersproject/web": "5.7.1",
-                "@ethersproject/wordlists": "5.7.0"
+                "@ethersproject/abi": "5.8.0",
+                "@ethersproject/abstract-provider": "5.8.0",
+                "@ethersproject/abstract-signer": "5.8.0",
+                "@ethersproject/address": "5.8.0",
+                "@ethersproject/base64": "5.8.0",
+                "@ethersproject/basex": "5.8.0",
+                "@ethersproject/bignumber": "5.8.0",
+                "@ethersproject/bytes": "5.8.0",
+                "@ethersproject/constants": "5.8.0",
+                "@ethersproject/contracts": "5.8.0",
+                "@ethersproject/hash": "5.8.0",
+                "@ethersproject/hdnode": "5.8.0",
+                "@ethersproject/json-wallets": "5.8.0",
+                "@ethersproject/keccak256": "5.8.0",
+                "@ethersproject/logger": "5.8.0",
+                "@ethersproject/networks": "5.8.0",
+                "@ethersproject/pbkdf2": "5.8.0",
+                "@ethersproject/properties": "5.8.0",
+                "@ethersproject/providers": "5.8.0",
+                "@ethersproject/random": "5.8.0",
+                "@ethersproject/rlp": "5.8.0",
+                "@ethersproject/sha2": "5.8.0",
+                "@ethersproject/signing-key": "5.8.0",
+                "@ethersproject/solidity": "5.8.0",
+                "@ethersproject/strings": "5.8.0",
+                "@ethersproject/transactions": "5.8.0",
+                "@ethersproject/units": "5.8.0",
+                "@ethersproject/wallet": "5.8.0",
+                "@ethersproject/web": "5.8.0",
+                "@ethersproject/wordlists": "5.8.0"
             }
         },
         "node_modules/ethereum-bloom-filters": {
@@ -6475,9 +6622,9 @@
             }
         },
         "node_modules/ethereum-bloom-filters/node_modules/@noble/hashes": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
-            "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+            "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -6725,9 +6872,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.5.tgz",
-            "integrity": "sha512-5JnBCWpFlMo0a3ciDy/JckMzzv1U9coZrIhedq+HXxxUfDTAiS0LA8OKVao4G9BxmCVck/jtA5r3KAtRWEyD8Q==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+            "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
             "dev": true,
             "funding": [
                 {
@@ -6742,9 +6889,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/fastq": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
-            "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
+            "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+            "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -6847,9 +6994,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-            "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
             "dev": true,
             "license": "ISC"
         },
@@ -6885,13 +7032,13 @@
             }
         },
         "node_modules/foreground-child": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-            "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "cross-spawn": "^7.0.0",
+                "cross-spawn": "^7.0.6",
                 "signal-exit": "^4.0.1"
             },
             "engines": {
@@ -6902,14 +7049,15 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-            "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+            "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
                 "mime-types": "^2.1.12"
             },
             "engines": {
@@ -6948,9 +7096,9 @@
             "license": "MIT"
         },
         "node_modules/fs-extra": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+            "version": "11.3.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+            "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7023,18 +7171,18 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-            "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
+                "call-bind-apply-helpers": "^1.0.2",
                 "es-define-property": "^1.0.1",
                 "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.0.0",
+                "es-object-atoms": "^1.1.1",
                 "function-bind": "^1.1.2",
-                "get-proto": "^1.0.0",
+                "get-proto": "^1.0.1",
                 "gopd": "^1.2.0",
                 "has-symbols": "^1.1.0",
                 "hasown": "^2.0.2",
@@ -7502,9 +7650,9 @@
             }
         },
         "node_modules/hardhat-deploy": {
-            "version": "0.12.4",
-            "resolved": "https://registry.npmjs.org/hardhat-deploy/-/hardhat-deploy-0.12.4.tgz",
-            "integrity": "sha512-bYO8DIyeGxZWlhnMoCBon9HNZb6ji0jQn7ngP1t5UmGhC8rQYhji7B73qETMOFhzt5ECZPr+U52duj3nubsqdQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/hardhat-deploy/-/hardhat-deploy-1.0.2.tgz",
+            "integrity": "sha512-FCeoGpYLQiGjROURihth6Qye+GWvRqalGbRsCTW33canhAS4g6mJEILbkWbWF8P2cPWgcpxe3cCJksk6n+oD7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7533,6 +7681,37 @@
                 "qs": "^6.9.4",
                 "zksync-ethers": "^5.0.0"
             }
+        },
+        "node_modules/hardhat-deploy/node_modules/@ethersproject/address": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+            "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/rlp": "^5.8.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/aes-js": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+            "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/hardhat-deploy/node_modules/axios": {
             "version": "0.21.4",
@@ -7569,7 +7748,889 @@
                 "fsevents": "~2.3.2"
             }
         },
+        "node_modules/hardhat-deploy/node_modules/elliptic": {
+            "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/elliptic/node_modules/bn.js": {
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+            "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/hardhat-deploy/node_modules/ethers": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.8.0.tgz",
+            "integrity": "sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abi": "5.8.0",
+                "@ethersproject/abstract-provider": "5.8.0",
+                "@ethersproject/abstract-signer": "5.8.0",
+                "@ethersproject/address": "5.8.0",
+                "@ethersproject/base64": "5.8.0",
+                "@ethersproject/basex": "5.8.0",
+                "@ethersproject/bignumber": "5.8.0",
+                "@ethersproject/bytes": "5.8.0",
+                "@ethersproject/constants": "5.8.0",
+                "@ethersproject/contracts": "5.8.0",
+                "@ethersproject/hash": "5.8.0",
+                "@ethersproject/hdnode": "5.8.0",
+                "@ethersproject/json-wallets": "5.8.0",
+                "@ethersproject/keccak256": "5.8.0",
+                "@ethersproject/logger": "5.8.0",
+                "@ethersproject/networks": "5.8.0",
+                "@ethersproject/pbkdf2": "5.8.0",
+                "@ethersproject/properties": "5.8.0",
+                "@ethersproject/providers": "5.8.0",
+                "@ethersproject/random": "5.8.0",
+                "@ethersproject/rlp": "5.8.0",
+                "@ethersproject/sha2": "5.8.0",
+                "@ethersproject/signing-key": "5.8.0",
+                "@ethersproject/solidity": "5.8.0",
+                "@ethersproject/strings": "5.8.0",
+                "@ethersproject/transactions": "5.8.0",
+                "@ethersproject/units": "5.8.0",
+                "@ethersproject/wallet": "5.8.0",
+                "@ethersproject/web": "5.8.0",
+                "@ethersproject/wordlists": "5.8.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/ws": {
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+            "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/zksync-ethers/-/zksync-ethers-5.10.0.tgz",
+            "integrity": "sha512-OAjTGAHF9wbdkRGkj7XZuF/a1Sk/FVbwH4pmLjAKlR7mJ7sQtQhBhrPU2dCc67xLaNvEESPfwil19ES5wooYFg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ethers": "~5.7.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "ethers": "~5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/abi": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+            "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/address": "^5.7.0",
+                "@ethersproject/bignumber": "^5.7.0",
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/constants": "^5.7.0",
+                "@ethersproject/hash": "^5.7.0",
+                "@ethersproject/keccak256": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0",
+                "@ethersproject/properties": "^5.7.0",
+                "@ethersproject/strings": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/abstract-provider": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+            "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.7.0",
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0",
+                "@ethersproject/networks": "^5.7.0",
+                "@ethersproject/properties": "^5.7.0",
+                "@ethersproject/transactions": "^5.7.0",
+                "@ethersproject/web": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/abstract-signer": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+            "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abstract-provider": "^5.7.0",
+                "@ethersproject/bignumber": "^5.7.0",
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0",
+                "@ethersproject/properties": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/address": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+            "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.7.0",
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/keccak256": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0",
+                "@ethersproject/rlp": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/base64": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+            "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/basex": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
+            "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/properties": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/bignumber": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+            "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0",
+                "bn.js": "^5.2.1"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/bytes": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+            "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/logger": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/constants": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+            "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/contracts": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+            "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abi": "^5.7.0",
+                "@ethersproject/abstract-provider": "^5.7.0",
+                "@ethersproject/abstract-signer": "^5.7.0",
+                "@ethersproject/address": "^5.7.0",
+                "@ethersproject/bignumber": "^5.7.0",
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/constants": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0",
+                "@ethersproject/properties": "^5.7.0",
+                "@ethersproject/transactions": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/hash": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+            "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abstract-signer": "^5.7.0",
+                "@ethersproject/address": "^5.7.0",
+                "@ethersproject/base64": "^5.7.0",
+                "@ethersproject/bignumber": "^5.7.0",
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/keccak256": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0",
+                "@ethersproject/properties": "^5.7.0",
+                "@ethersproject/strings": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/hdnode": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+            "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abstract-signer": "^5.7.0",
+                "@ethersproject/basex": "^5.7.0",
+                "@ethersproject/bignumber": "^5.7.0",
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0",
+                "@ethersproject/pbkdf2": "^5.7.0",
+                "@ethersproject/properties": "^5.7.0",
+                "@ethersproject/sha2": "^5.7.0",
+                "@ethersproject/signing-key": "^5.7.0",
+                "@ethersproject/strings": "^5.7.0",
+                "@ethersproject/transactions": "^5.7.0",
+                "@ethersproject/wordlists": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/json-wallets": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+            "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abstract-signer": "^5.7.0",
+                "@ethersproject/address": "^5.7.0",
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/hdnode": "^5.7.0",
+                "@ethersproject/keccak256": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0",
+                "@ethersproject/pbkdf2": "^5.7.0",
+                "@ethersproject/properties": "^5.7.0",
+                "@ethersproject/random": "^5.7.0",
+                "@ethersproject/strings": "^5.7.0",
+                "@ethersproject/transactions": "^5.7.0",
+                "aes-js": "3.0.0",
+                "scrypt-js": "3.0.1"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/keccak256": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+            "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.7.0",
+                "js-sha3": "0.8.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/logger": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+            "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/networks": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
+            "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/logger": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/pbkdf2": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+            "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/sha2": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/properties": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+            "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/logger": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/providers": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
+            "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abstract-provider": "^5.7.0",
+                "@ethersproject/abstract-signer": "^5.7.0",
+                "@ethersproject/address": "^5.7.0",
+                "@ethersproject/base64": "^5.7.0",
+                "@ethersproject/basex": "^5.7.0",
+                "@ethersproject/bignumber": "^5.7.0",
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/constants": "^5.7.0",
+                "@ethersproject/hash": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0",
+                "@ethersproject/networks": "^5.7.0",
+                "@ethersproject/properties": "^5.7.0",
+                "@ethersproject/random": "^5.7.0",
+                "@ethersproject/rlp": "^5.7.0",
+                "@ethersproject/sha2": "^5.7.0",
+                "@ethersproject/strings": "^5.7.0",
+                "@ethersproject/transactions": "^5.7.0",
+                "@ethersproject/web": "^5.7.0",
+                "bech32": "1.1.4",
+                "ws": "7.4.6"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/random": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
+            "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/rlp": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+            "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/sha2": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
+            "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0",
+                "hash.js": "1.1.7"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/signing-key": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+            "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0",
+                "@ethersproject/properties": "^5.7.0",
+                "bn.js": "^5.2.1",
+                "elliptic": "6.5.4",
+                "hash.js": "1.1.7"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/solidity": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
+            "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.7.0",
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/keccak256": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0",
+                "@ethersproject/sha2": "^5.7.0",
+                "@ethersproject/strings": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/strings": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+            "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/constants": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/transactions": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+            "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/address": "^5.7.0",
+                "@ethersproject/bignumber": "^5.7.0",
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/constants": "^5.7.0",
+                "@ethersproject/keccak256": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0",
+                "@ethersproject/properties": "^5.7.0",
+                "@ethersproject/rlp": "^5.7.0",
+                "@ethersproject/signing-key": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/units": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
+            "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.7.0",
+                "@ethersproject/constants": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/wallet": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+            "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abstract-provider": "^5.7.0",
+                "@ethersproject/abstract-signer": "^5.7.0",
+                "@ethersproject/address": "^5.7.0",
+                "@ethersproject/bignumber": "^5.7.0",
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/hash": "^5.7.0",
+                "@ethersproject/hdnode": "^5.7.0",
+                "@ethersproject/json-wallets": "^5.7.0",
+                "@ethersproject/keccak256": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0",
+                "@ethersproject/properties": "^5.7.0",
+                "@ethersproject/random": "^5.7.0",
+                "@ethersproject/signing-key": "^5.7.0",
+                "@ethersproject/transactions": "^5.7.0",
+                "@ethersproject/wordlists": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/web": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
+            "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/base64": "^5.7.0",
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0",
+                "@ethersproject/properties": "^5.7.0",
+                "@ethersproject/strings": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/@ethersproject/wordlists": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+            "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/hash": "^5.7.0",
+                "@ethersproject/logger": "^5.7.0",
+                "@ethersproject/properties": "^5.7.0",
+                "@ethersproject/strings": "^5.7.0"
+            }
+        },
+        "node_modules/hardhat-deploy/node_modules/zksync-ethers/node_modules/ethers": {
             "version": "5.7.2",
             "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
             "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
@@ -7616,63 +8677,6 @@
                 "@ethersproject/wallet": "5.7.0",
                 "@ethersproject/web": "5.7.1",
                 "@ethersproject/wordlists": "5.7.0"
-            }
-        },
-        "node_modules/hardhat-deploy/node_modules/fs-extra": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/hardhat-deploy/node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/hardhat-deploy/node_modules/readdirp": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "picomatch": "^2.2.1"
-            },
-            "engines": {
-                "node": ">=8.10.0"
-            }
-        },
-        "node_modules/hardhat-deploy/node_modules/zksync-ethers": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/zksync-ethers/-/zksync-ethers-5.10.0.tgz",
-            "integrity": "sha512-OAjTGAHF9wbdkRGkj7XZuF/a1Sk/FVbwH4pmLjAKlR7mJ7sQtQhBhrPU2dCc67xLaNvEESPfwil19ES5wooYFg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ethers": "~5.7.0"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "ethers": "~5.7.0"
             }
         },
         "node_modules/hardhat-gas-reporter": {
@@ -7737,6 +8741,44 @@
             "dependencies": {
                 "@noble/hashes": "~1.2.0",
                 "@scure/base": "~1.1.0"
+            }
+        },
+        "node_modules/hardhat/node_modules/@sentry/core": {
+            "version": "5.30.0",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
+            "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sentry/hub": "5.30.0",
+                "@sentry/minimal": "5.30.0",
+                "@sentry/types": "5.30.0",
+                "@sentry/utils": "5.30.0",
+                "tslib": "^1.9.3"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/hardhat/node_modules/@sentry/node": {
+            "version": "5.30.0",
+            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.30.0.tgz",
+            "integrity": "sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sentry/core": "5.30.0",
+                "@sentry/hub": "5.30.0",
+                "@sentry/tracing": "5.30.0",
+                "@sentry/types": "5.30.0",
+                "@sentry/utils": "5.30.0",
+                "cookie": "^0.4.1",
+                "https-proxy-agent": "^5.0.0",
+                "lru_map": "^0.3.3",
+                "tslib": "^1.9.3"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/hardhat/node_modules/commander": {
@@ -7829,10 +8871,17 @@
                 "semver": "bin/semver"
             }
         },
+        "node_modules/hardhat/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true,
+            "license": "0BSD"
+        },
         "node_modules/hardhat/node_modules/undici": {
-            "version": "5.28.5",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
-            "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7900,6 +8949,22 @@
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
             "engines": {
                 "node": ">= 0.4"
             },
@@ -8144,9 +9209,9 @@
             "license": "MIT"
         },
         "node_modules/import-fresh": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8684,6 +9749,7 @@
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
             "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+            "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
             "dev": true,
             "license": "MIT"
         },
@@ -8691,6 +9757,7 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
             "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+            "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
             "dev": true,
             "license": "MIT"
         },
@@ -8726,9 +9793,9 @@
             }
         },
         "node_modules/long": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/long/-/long-5.2.4.tgz",
-            "integrity": "sha512-qtzLbJE8hq7VabR3mISmVGtoXP8KGc2Z/AT8OuqlYD7JTR3oqrgwdjnk07wpj1twXxYmgDXgoKVWUG/fReSzHg==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
+            "integrity": "sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng==",
             "dev": true,
             "license": "Apache-2.0"
         },
@@ -8785,9 +9852,9 @@
             "peer": true
         },
         "node_modules/match-all": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/match-all/-/match-all-1.2.6.tgz",
-            "integrity": "sha512-0EESkXiTkWzrQQntBu2uzKvLu6vVkUGz40nGPbSZuegcfE5UuSzNjLaIu76zJWuaT/2I3Z/8M06OlUOZLGwLlQ==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/match-all/-/match-all-1.2.7.tgz",
+            "integrity": "sha512-qSpsBKarh55r9KyXzFC3xBLRf2GlGasba2em9kbpRsSlGvdTAqjx3QD0r3FKSARiW+OE4iMHYsolM3aX9n5djw==",
             "dev": true,
             "license": "MIT"
         },
@@ -9182,9 +10249,9 @@
             }
         },
         "node_modules/nan": {
-            "version": "2.22.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
-            "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+            "version": "2.22.2",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
+            "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
             "dev": true,
             "license": "MIT",
             "optional": true
@@ -9383,9 +10450,9 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.13.3",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-            "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9998,13 +11065,13 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.13.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
-            "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.0.6"
+                "side-channel": "^1.1.0"
             },
             "engines": {
                 "node": ">=0.6"
@@ -10115,13 +11182,13 @@
             }
         },
         "node_modules/readdirp": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
-            "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 14.16.0"
+                "node": ">= 14.18.0"
             },
             "funding": {
                 "type": "individual",
@@ -10203,9 +11270,9 @@
             }
         },
         "node_modules/registry-auth-token": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.3.tgz",
-            "integrity": "sha512-1bpc9IyC+e+CNFRaWyn77tk4xGG4PPUyfakSmA6F6cvUDjrm58dfyJ3II+9yb10EDkHoy1LaPSmHaWLOH3m6HA==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.0.tgz",
+            "integrity": "sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10383,9 +11450,9 @@
             }
         },
         "node_modules/reusify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10438,9 +11505,9 @@
             }
         },
         "node_modules/rimraf/node_modules/jackspeak": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
-            "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
+            "integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -10454,9 +11521,9 @@
             }
         },
         "node_modules/rimraf/node_modules/lru-cache": {
-            "version": "11.0.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
-            "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+            "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -10755,29 +11822,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/secp256k1/node_modules/bn.js": {
-            "version": "4.12.1",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-            "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/secp256k1/node_modules/elliptic": {
-            "version": "6.6.1",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-            "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bn.js": "^4.11.9",
-                "brorand": "^1.1.0",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.1",
-                "inherits": "^2.0.4",
-                "minimalistic-assert": "^1.0.1",
-                "minimalistic-crypto-utils": "^1.0.1"
-            }
-        },
         "node_modules/secp256k1/node_modules/node-addon-api": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
@@ -10786,9 +11830,9 @@
             "license": "MIT"
         },
         "node_modules/semver": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -11570,9 +12614,9 @@
             }
         },
         "node_modules/stacktrace-parser": {
-            "version": "0.1.10",
-            "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz",
-            "integrity": "sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==",
+            "version": "0.1.11",
+            "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
+            "integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11863,16 +12907,16 @@
             "license": "MIT"
         },
         "node_modules/tar-fs": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
-            "integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+            "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "chownr": "^1.1.1",
                 "mkdirp-classic": "^0.5.2",
                 "pump": "^3.0.0",
-                "tar-stream": "^2.0.0"
+                "tar-stream": "^2.1.4"
             }
         },
         "node_modules/tar-stream": {
@@ -11932,16 +12976,17 @@
             "peer": true
         },
         "node_modules/then-request/node_modules/form-data": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.2.tgz",
-            "integrity": "sha512-GgwY0PS7DbXqajuGf4OYlsrIu3zgxD6Vvql43IBhm6MahqA5SK/7mwhtNj2AdH2z35YR34ujJ7BN+3fFC3jP5Q==",
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
+            "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "mime-types": "^2.1.35",
                 "safe-buffer": "^5.2.1"
             },
             "engines": {
@@ -11967,23 +13012,26 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
-            "integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
+            "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fdir": "^6.4.2",
+                "fdir": "^6.4.3",
                 "picomatch": "^4.0.2"
             },
             "engines": {
                 "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
             }
         },
         "node_modules/tinyglobby/node_modules/fdir": {
-            "version": "6.4.2",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
-            "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
+            "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -12444,9 +13492,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "6.21.1",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-            "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+            "version": "6.21.2",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
+            "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12506,9 +13554,9 @@
             "license": "MIT"
         },
         "node_modules/uuid": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-            "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
             "dev": true,
             "funding": [
                 "https://github.com/sponsors/broofa",
@@ -12516,7 +13564,7 @@
             ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "eslint-plugin-no-only-tests": "^3.3.0",
         "eslint-plugin-prettier": "^5.2.6",
         "hardhat": "^2.22.19",
-        "hardhat-deploy": "^0.12.4",
+        "hardhat-deploy": "^1.0.2",
         "husky": "^9.1.7",
         "prettier": "^3.5.3",
         "prettier-plugin-solidity": "^1.4.2",


### PR DESCRIPTION
I noticed that transistive dependencies weren't updated in the previous PR, so I did so with `npm update`. I also updated to the latest `hardhat-deploy` (and am not sure why it was excluded from the previous PR as things seem to work as expected - maybe @mmv08 knows?).