### PR TITLE
Fix Coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,12 @@ jobs:
               uses: coverallsapp/github-action@v2
               with:
                   parallel: true
-                  flag-name: run-$
+                  flag-name: run-${{ matrix.contract-name }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
     finish:
         runs-on: ubuntu-latest
-        needs: tests
+        needs: coverage
         if: ${{ always() }}
         steps:
             - name: Coveralls Finished


### PR DESCRIPTION
Coveralls parallel builds need some additional configuration, it looks like it was sporadically failing in CI, and I think it was misconfigured:
- We want the flag name to be the contract name from the coverage matrix
- We want finishing to depend on the `coverage` step and not the testing step

Changes were done based on the documentation here: https://docs.coveralls.io/parallel-builds