### PR TITLE
docs: replace outdated zkSync SELFDESTRUCT reference link

### DIFF
--- a/test/core/Safe.StorageAccessible.spec.ts
+++ b/test/core/Safe.StorageAccessible.spec.ts
@@ -38,7 +38,7 @@ describe("StorageAccessible", () => {
             /**
              * ## Test not applicable for zkSync, therefore should skip.
              * The `SELFDESTRUCT` instruction is not supported
-             * @see https://era.zksync.io/docs/reference/architecture/differences-with-ethereum.html#selfdestruct
+             * @see https://docs.zksync.io/zksync-protocol/differences/evm-instructions#selfdestruct
              */
             if (hre.network.zksync) this.skip();
 

--- a/test/handlers/CompatibilityFallbackHandler.spec.ts
+++ b/test/handlers/CompatibilityFallbackHandler.spec.ts
@@ -206,7 +206,7 @@ describe("CompatibilityFallbackHandler", () => {
             /**
              * ## Test not applicable for zkSync, therefore should skip.
              * The `SELFDESTRUCT` instruction is not supported
-             * @see https://era.zksync.io/docs/reference/architecture/differences-with-ethereum.html#selfdestruct
+             * @see https://docs.zksync.io/zksync-protocol/differences/evm-instructions#selfdestruct
              */
             if (hre.network.zksync) this.skip();
 

--- a/test/libraries/MultiSend.spec.ts
+++ b/test/libraries/MultiSend.spec.ts
@@ -44,7 +44,7 @@ describe("MultiSend", () => {
             /**
              * ## Test not applicable for zkSync, therefore should skip.
              * The `SELFDESTRUCT` instruction is not supported
-             * @see https://era.zksync.io/docs/reference/architecture/differences-with-ethereum.html#selfdestruct
+             * @see https://docs.zksync.io/zksync-protocol/differences/evm-instructions#selfdestruct
              */
             if (hre.network.zksync) this.skip();
 


### PR DESCRIPTION
Description
- Updates the broken URL `era.zksync.io/docs/reference/architecture/differences-with-ethereum.html#selfdestruct`
  to `https://docs.zksync.io/zksync-protocol/differences/evm-instructions#selfdestruct`.
- Restores a valid external reference for the SELFDESTRUCT opcode section in zkSync Era docs.
- Docs-only change; no functional code impact.

All files verified; all links fixed.