### PR TITLE
Ackee[L2]: Backwards Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,13 +149,13 @@ Issues:
 -   [#557](https://github.com/safe-global/safe-smart-account/pull/557)
 -   [#589](https://github.com/safe-global/safe-smart-account/pull/589)
 
-Previously pre-approved signatures relying on the `msg.sender` variable couldn't be used in guards or modules without duplicating the logic within the module itself. This is now improved by adding an overloaded `checkNSignatures` method that accepts a `msg.sender` parameter. This allows the module to pass the `msg.sender` variable to the `checkNSignatures` method and use the pre-approved signatures. The old method was moved from the core contract to the `CompatibilityFallbackHandler`.
+Previously pre-approved signatures relying on the `msg.sender` variable couldn't be used in guards or modules without duplicating the logic within the module itself. This is now improved by adding an overloaded `checkNSignatures` method that accepts a `msg.sender` parameter. This allows the module to pass the `msg.sender` variable to the `checkNSignatures` method and use the pre-approved signatures. The old method was kept for backwards compatibility.
 
 #### Remove `encodeTransactionData` and add inline-assembly-based encoding in `getTransactionHash`
 
 PR: [#603](https://github.com/safe-global/safe-smart-account/pull/603)
 
-The `encodeTransactionData` function has been refactored in two stages since the last release. Initially, due to bytecode size constraints, it was modified in PR [#603](https://github.com/safe-global/safe-smart-account/pull/603) to a `private` function. Subsequently, in PR [#847](https://github.com/safe-global/safe-smart-account/pull/847), `encodeTransactionData` was entirely removed and replaced with an optimized, inline-assembly implementation within the `getTransactionHash` function.
+The `encodeTransactionData` function has been refactored in two stages since the last release. Initially, due to bytecode size constraints, it was modified in PR [#603](https://github.com/safe-global/safe-smart-account/pull/603) to a `private` function. Subsequently, in PR [#847](https://github.com/safe-global/safe-smart-account/pull/847), `encodeTransactionData` was entirely removed and replaced with an optimized, inline-assembly implementation within the `getTransactionHash` function. Note that `encodeTransactionData` was added to the `CompatibilityFallbackHandler` for backwards compatibility.
 
 # Version 1.4.1
 

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.7.0 <0.9.0;
 
 import {ISafe} from "./../interfaces/ISafe.sol";
 import {ISignatureValidator} from "./../interfaces/ISignatureValidator.sol";
+import {Enum} from "./../libraries/Enum.sol";
 import {HandlerContext} from "./HandlerContext.sol";
 import {TokenCallbackHandler} from "./TokenCallbackHandler.sol";
 
@@ -19,6 +20,12 @@ contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidat
      *      Precomputed value of: `keccak256("SafeMessage(bytes message)")`.
      */
     bytes32 private constant SAFE_MSG_TYPEHASH = 0x60b3cbf8b4a223d68d641b3b6ddf9a298e7f33710cf3d3a9d1146b5a6150fbca;
+
+    /**
+     * @dev The precomputed EIP-712 type hash for the Safe transaction type.
+     *      Precomputed value of: `keccak256("SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)")`.
+     */
+    bytes32 private constant SAFE_TX_TYPEHASH = 0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8;
 
     /**
      * @dev The sentinel module value in the {ModuleManager.modules} linked list.
@@ -170,5 +177,54 @@ contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidat
             }
         }
         /* solhint-enable no-inline-assembly */
+    }
+
+    /**
+     * @notice Returns the pre-image of the Safe transaction hash (see {Safe.getTransactionHash}).
+     * @dev This method is added to the {CompatibilityFallbackHandler} for backwards compatibility with previous versions of Safe.
+     *      For a given Safe, the invariant `getTransactionHash(...) == keccak256(encodeTransactionData(...))` holds true.
+     * @param to Destination address of the Safe transaction.
+     * @param value Native token value of the Safe transaction.
+     * @param data Data payload of the Safe transaction.
+     * @param operation Operation type of the Safe transaction: 0 for `CALL` and 1 for `DELEGATECALL`.
+     * @param safeTxGas Gas that should be used for the Safe transaction.
+     * @param baseGas Base gas costs that are independent of the transaction execution (e.g. base transaction fee, signature check, payment of the refund).
+     * @param gasPrice Gas price that should be used for the payment calculation.
+     * @param gasToken Token address (or 0 for the native token) that is used for the payment.
+     * @param refundReceiver Address of receiver of the gas payment (or 0 for `tx.origin`).
+     * @param nonce Transaction nonce.
+     * @return Transaction hash pre-image bytes.
+     */
+    function encodeTransactionData(
+        address to,
+        uint256 value,
+        bytes calldata data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address refundReceiver,
+        uint256 nonce
+    ) public view returns (bytes memory) {
+        // Caller should be a Safe.
+        ISafe safe = ISafe(payable(msg.sender));
+        bytes32 domainSeparator = safe.domainSeparator();
+        bytes32 safeTxHash = keccak256(
+            abi.encode(
+                SAFE_TX_TYPEHASH,
+                to,
+                value,
+                keccak256(data),
+                operation,
+                safeTxGas,
+                baseGas,
+                gasPrice,
+                gasToken,
+                refundReceiver,
+                nonce
+            )
+        );
+        return abi.encodePacked(bytes1(0x19), bytes1(0x01), domainSeparator, safeTxHash);
     }
 }

--- a/test/handlers/CompatibilityFallbackHandler.spec.ts
+++ b/test/handlers/CompatibilityFallbackHandler.spec.ts
@@ -266,7 +266,7 @@ describe("CompatibilityFallbackHandler", () => {
     describe("encodeTransactionData", () => {
         it("should return the pre-image of a transaction hash", async () => {
             const { safe, validator } = await setupTests();
-            const tx = [`0x${"11".repeat(20)}`, 1, "0x01020304", 0, 4, 5, 6, `0x${"77".repeat(20)}`, `0x${"88".repeat(20)}`, 9];
+            const tx = [`0x${"11".repeat(20)}`, 1, "0x01020304", 0, 4, 5, 6, `0x${"77".repeat(20)}`, `0x${"88".repeat(20)}`, 9] as const;
             expect(ethers.keccak256(await validator.encodeTransactionData(...tx))).to.be.eq(await safe.getTransactionHash(...tx));
         });
     });

--- a/test/handlers/CompatibilityFallbackHandler.spec.ts
+++ b/test/handlers/CompatibilityFallbackHandler.spec.ts
@@ -262,4 +262,12 @@ describe("CompatibilityFallbackHandler", () => {
             }
         });
     });
+
+    describe("encodeTransactionData", () => {
+        it("should return the pre-image of a transaction hash", async () => {
+            const { safe, validator } = await setupTests();
+            const tx = [`0x${"11".repeat(20)}`, 1, "0x01020304", 0, 4, 5, 6, `0x${"77".repeat(20)}`, `0x${"88".repeat(20)}`, 9];
+            expect(ethers.keccak256(await validator.encodeTransactionData(...tx))).to.be.eq(await safe.getTransactionHash(...tx));
+        });
+    });
 });


### PR DESCRIPTION
This PR adjusts the CHANGELOG to correctly reflect where the `checkNSignatures` backwards compatible method is (Safe) and adds a backwards compatible `encodeTransactionData` method to the `CompatibilityFallbackHandler`.