### PR TITLE
Ackee[L3]: Mask `masterCopy` Selector

### DIFF
--- a/contracts/proxies/SafeProxy.sol
+++ b/contracts/proxies/SafeProxy.sol
@@ -38,8 +38,9 @@ contract SafeProxy {
         /* solhint-disable no-inline-assembly */
         assembly {
             let _singleton := sload(0)
-            // 0xa619486e == bytes4(keccak256("masterCopy()")). The value is right padded to 32-bytes with 0s
-            if eq(calldataload(0), 0xa619486e00000000000000000000000000000000000000000000000000000000) {
+            // 0xa619486e == uint32(bytes4(keccak256("masterCopy()"))). Only the 4 first bytes of calldata are
+            // considered to make it 100% Solidity ABI conformant.
+            if eq(shr(224, calldataload(0)), 0xa619486e) {
                 // We mask the singleton address when handling the `masterCopy()` call to ensure that it is correctly
                 // ABI-encoded. We do this by shifting the address left by 96 bits (or 12 bytes) and then storing it in
                 // memory with a 12 byte offset from where the return data starts. Note that we **intentionally** only

--- a/test/factory/Proxy.spec.ts
+++ b/test/factory/Proxy.spec.ts
@@ -44,6 +44,17 @@ describe("Proxy", () => {
             expect(await proxy.masterCopy()).to.equal(await singleton.getAddress());
         });
 
+        it("should ignore extra calldata bytes", async () => {
+            const { singleton, proxy } = await setupTests();
+            const callData = hre.ethers.concat([proxy.interface.encodeFunctionData("masterCopy", []), "0xbaddad"]);
+            const returnData = await hre.ethers.provider.call({
+                to: await proxy.getAddress(),
+                data: callData,
+            });
+            const [masterCopy] = hre.ethers.AbiCoder.defaultAbiCoder().decode(["address"], returnData);
+            expect(masterCopy).to.equal(await singleton.getAddress());
+        });
+
         it("should correctly mask the address value", async () => {
             const { proxy } = await setupTests();
             await proxy.overwriteSingletonSlot(hre.ethers.MaxUint256);


### PR DESCRIPTION
This PR changes the proxy implementation slightly to mask the `masterCopy` selector instead of assuming that the trailing bytes are 0. This makes the `masterCopy()` handling Solidity ABI conformant. Without this change, the `masterCopy` function would not be able to be used behind an ERC-2771 trusted forwarder for example.