### PR TITLE
Ackee[W4]: `SafeSetup` Outdated Event Parameters

### DIFF
--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -91,6 +91,11 @@ contract Safe is
         uint256 payment,
         address payable paymentReceiver
     ) external override {
+        // Emit the setup event optimistically. This ensures that changes such as `addOwner` and `changeThreshold` that are part
+        // of the  `to.delegatecall(data)` that happen in the `setupModules` call emit events in order relative to the setup
+        // event, making it easier for off-chain indexers to reliably reconstruct the Safe configuration.
+        emit SafeSetup(msg.sender, _owners, _threshold, to, fallbackHandler);
+
         // setupOwners checks if the Threshold is already set, therefore preventing this method from being called more than once
         setupOwners(_owners, _threshold);
         if (fallbackHandler != address(0)) internalSetFallbackHandler(fallbackHandler);
@@ -102,11 +107,6 @@ contract Safe is
             // baseGas = 0, gasPrice = 1 and gas = payment => amount = (payment + 0) * 1 = payment
             handlePayment(payment, 0, 1, paymentToken, paymentReceiver);
         }
-
-        // Note that we use the setup function parameters instead of reading from storage here. This may mean that the
-        // event parameters are inaccurate if the `to.delegatecall(data)` modified any of them (such as adding or
-        // removing owners, changing the threshold or resetting the fallback handler).
-        emit SafeSetup(msg.sender, _owners, _threshold, to, fallbackHandler);
     }
 
     /**

--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -102,6 +102,10 @@ contract Safe is
             // baseGas = 0, gasPrice = 1 and gas = payment => amount = (payment + 0) * 1 = payment
             handlePayment(payment, 0, 1, paymentToken, paymentReceiver);
         }
+
+        // Note that we use the setup function parameters instead of reading from storage here. This may mean that the
+        // event parameters are inaccurate if the `to.delegatecall(data)` modified any of them (such as adding or
+        // removing owners, changing the threshold or resetting the fallback handler).
         emit SafeSetup(msg.sender, _owners, _threshold, to, fallbackHandler);
     }
 

--- a/contracts/interfaces/ISafe.sol
+++ b/contracts/interfaces/ISafe.sol
@@ -22,6 +22,8 @@ interface ISafe is IModuleManager, IGuardManager, IOwnerManager, IFallbackManage
      * @notice Sets an initial storage of the Safe contract.
      * @dev This method can only be called once.
      *      If a proxy was created without setting up, anyone can call setup and claim the proxy.
+     *      This method emits a {SafeSetup} event with the setup parameters instead of reading from storage,
+     *      which may be inaccurate if the delegate call to `to` modifies the owners, threshold or fallback handler.
      * @param _owners List of Safe owners.
      * @param _threshold Number of required confirmations for a Safe transaction.
      * @param to Contract address for optional delegate call.


### PR DESCRIPTION
We document that the `SafeSetup` may emit an event with outdated parameters if the initializer `DELEGATECALL` modifies any of them on the Safe.