### PR TITLE
Ackee[W6]: Prevent `TokenCallbackHandler` from Locking Tokens

### DIFF
--- a/contracts/common/StorageAccessible.sol
+++ b/contracts/common/StorageAccessible.sol
@@ -1,20 +1,19 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
+import {IStorageAccessible} from "../interfaces/IStorageAccessible.sol";
+
 /**
  * @title StorageAccessible - A generic base contract that allows callers to access all internal storage.
  * @notice See https://github.com/gnosis/util-contracts/blob/bb5fe5fb5df6d8400998094fb1b32a178a47c3a1/contracts/StorageAccessible.sol
  *         It removes a method from the original contract not needed for the Safe Smart Account contracts.
  * @author Gnosis Developers
  */
-abstract contract StorageAccessible {
+abstract contract StorageAccessible is IStorageAccessible {
     /**
-     * @notice Reads `length` bytes of storage in the current contract
-     * @param offset - the offset in the current contract's storage in words to start reading from
-     * @param length - the number of words (32 bytes) of data to read
-     * @return the bytes that were read.
+     * @inheritdoc IStorageAccessible
      */
-    function getStorageAt(uint256 offset, uint256 length) public view returns (bytes memory) {
+    function getStorageAt(uint256 offset, uint256 length) public view override returns (bytes memory) {
         // We use `<< 5` instead of `* 32` as SHR / SHL opcode only uses 3 gas, while DIV / MUL opcode uses 5 gas.
         bytes memory result = new bytes(length << 5);
         for (uint256 index = 0; index < length; ++index) {
@@ -30,17 +29,9 @@ abstract contract StorageAccessible {
     }
 
     /**
-     * @dev Performs a delegatecall on a targetContract in the context of self.
-     * Internally reverts execution to avoid side effects (making it effectively static).
-     *
-     * This method reverts with data equal to `abi.encodePacked(uint256(success), uint256(response.length), bytes(response))`.
-     * Specifically, the `returndata` after a call to this method will be:
-     * `success:uint256 || response.length:uint256 || response:bytes`.
-     *
-     * @param targetContract Address of the contract containing the code to execute.
-     * @param calldataPayload Calldata that should be sent to the target contract (encoded method name and arguments).
+     * @inheritdoc IStorageAccessible
      */
-    function simulateAndRevert(address targetContract, bytes memory calldataPayload) external {
+    function simulateAndRevert(address targetContract, bytes memory calldataPayload) external override {
         /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly
         assembly {

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.7.0 <0.9.0;
 import {ISafe} from "./../interfaces/ISafe.sol";
 import {ISignatureValidator} from "./../interfaces/ISignatureValidator.sol";
 import {Enum} from "./../libraries/Enum.sol";
-import {HandlerContext} from "./HandlerContext.sol";
 import {TokenCallbackHandler} from "./TokenCallbackHandler.sol";
 
 /**
@@ -14,7 +13,7 @@ import {TokenCallbackHandler} from "./TokenCallbackHandler.sol";
  *      Using it in other ways may cause undefined behavior. ⚠️⚠️⚠️
  * @author Richard Meissner - @rmeissner
  */
-contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidator, HandlerContext {
+contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidator {
     /**
      * @dev The precomputed EIP-712 type hash for the Safe message type.
      *      Precomputed value of: `keccak256("SafeMessage(bytes message)")`.

--- a/contracts/handler/HandlerContext.sol
+++ b/contracts/handler/HandlerContext.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
+import {ISafe} from "../interfaces/ISafe.sol";
+
 /**
  * @title Handler Context - Allows the fallback handler to extract additional context from the calldata
  * @dev The fallback manager appends the following context to the calldata:
@@ -9,6 +11,35 @@ pragma solidity >=0.7.0 <0.9.0;
  * @author Richard Meissner - @rmeissner
  */
 abstract contract HandlerContext {
+    /**
+     * @dev The storage slot used for storing the currently configured fallback handler address.
+     *      Precomputed value of: `keccak256("fallback_manager.handler.address")`.
+     */
+    bytes32 internal constant FALLBACK_HANDLER_STORAGE_SLOT = 0x6c9a6c4a39284e37ed1cf53d337577d14212a4870fb976a4366c693b939918d5;
+
+    /**
+     * @notice A modifier that reverts if not called by a Safe as a fallback handler.
+     * @dev Note that this modifier does a **best effort** attempt at not allowing calls that are
+     *      not as a fallback call, but it still can be tricked. It is suitable for use cases such
+     *      making a best effort attempt to disallow ERC-721 and ERC-1155 token transfers to the
+     *      fallback handler contract.
+     */
+    modifier onlyFallback() {
+        _requireFallback();
+        _;
+    }
+
+    /**
+     * @dev Implementation of the {onlySafeFallback} modifier check that the current call is a Safe
+     *      fallback call, and the contract is not called directly. Note that this is only a **best
+     *      effort** check and may generate false positives under certain conditions.
+     */
+    function _requireFallback() internal view {
+        bytes memory storageData = ISafe(payable(msg.sender)).getStorageAt(uint256(FALLBACK_HANDLER_STORAGE_SLOT), 1);
+        address fallbackHandler = abi.decode(storageData, (address));
+        require(fallbackHandler == address(this), "not a fallback call");
+    }
+
     /**
      * @notice Allows fetching the original caller address.
      * @dev This is only reliable in combination with a FallbackManager that supports this (e.g. Safe contract >=1.3.0).

--- a/contracts/handler/TokenCallbackHandler.sol
+++ b/contracts/handler/TokenCallbackHandler.sol
@@ -5,22 +5,27 @@ import {ERC1155TokenReceiver} from "../interfaces/ERC1155TokenReceiver.sol";
 import {ERC721TokenReceiver} from "../interfaces/ERC721TokenReceiver.sol";
 import {ERC777TokensRecipient} from "../interfaces/ERC777TokensRecipient.sol";
 import {IERC165} from "../interfaces/IERC165.sol";
+import {HandlerContext} from "./HandlerContext.sol";
 
 /**
- * @title Default Callback Handler - Handles supported tokens' callbacks, allowing Safes to receive these tokens.
+ * @title Token Callback Handler
+ * @notice Handles supported tokens' callbacks, allowing Safes to receive these tokens.
+ * @dev ⚠️ WARNING: This contract implements various token callback functions, which makes it
+ *      possible for itself to receive these tokens despite not being designed to do so,
+ *      PERMANENTLY LOCKING THOSE TOKENS. Do not send tokens to this contract.
  * @author Richard Meissner - @rmeissner
  */
-contract TokenCallbackHandler is ERC1155TokenReceiver, ERC777TokensRecipient, ERC721TokenReceiver, IERC165 {
+contract TokenCallbackHandler is HandlerContext, ERC1155TokenReceiver, ERC777TokensRecipient, ERC721TokenReceiver, IERC165 {
     /**
-     * @notice Handles ERC1155 Token callback.
+     * @notice Handles ERC-1155 Token callback.
      * @return Standardized onERC1155Received return value.
      */
-    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external pure override returns (bytes4) {
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external view override onlyFallback returns (bytes4) {
         return 0xf23a6e61;
     }
 
     /**
-     * @notice Handles ERC1155 Token batch callback.
+     * @notice Handles ERC-1155 Token batch callback.
      * @return Standardized onERC1155BatchReceived return value.
      */
     function onERC1155BatchReceived(
@@ -29,20 +34,20 @@ contract TokenCallbackHandler is ERC1155TokenReceiver, ERC777TokensRecipient, ER
         uint256[] calldata,
         uint256[] calldata,
         bytes calldata
-    ) external pure override returns (bytes4) {
+    ) external view override onlyFallback returns (bytes4) {
         return 0xbc197c81;
     }
 
     /**
-     * @notice Handles ERC721 Token callback.
+     * @notice Handles ERC-721 Token callback.
      * @return Standardized onERC721Received return value.
      */
-    function onERC721Received(address, address, uint256, bytes calldata) external pure override returns (bytes4) {
+    function onERC721Received(address, address, uint256, bytes calldata) external view override onlyFallback returns (bytes4) {
         return 0x150b7a02;
     }
 
     /**
-     * @notice Handles ERC777 Token callback.
+     * @notice Handles ERC-777 Token callback.
      * @dev Account that wishes to receive the tokens also needs to register the implementer (this contract) via the ERC-1820 interface registry.
      *      From the standard: "This is done by calling the setInterfaceImplementer function on the ERC-1820 registry with the holder address as
      *      the address, the keccak256 hash of ERC777TokensSender (0x29ddb589b1fb5fc7cf394961c1adf5f8c6454761adf795e67fe149f658abe895) as the
@@ -53,7 +58,7 @@ contract TokenCallbackHandler is ERC1155TokenReceiver, ERC777TokensRecipient, ER
     }
 
     /**
-     * @notice Implements ERC165 interface support for ERC1155TokenReceiver, ERC721TokenReceiver and IERC165.
+     * @notice Implements ERC-165 interface support for ERC1155TokenReceiver, ERC721TokenReceiver and IERC165.
      * @param interfaceId Id of the interface.
      * @return if the interface is supported.
      */

--- a/contracts/handler/extensible/TokenCallbacks.sol
+++ b/contracts/handler/extensible/TokenCallbacks.sol
@@ -7,22 +7,22 @@ import {ERC721TokenReceiver} from "../../interfaces/ERC721TokenReceiver.sol";
 import {ExtensibleBase} from "./ExtensibleBase.sol";
 
 /**
- * @title TokenCallbacks - ERC1155 and ERC721 token callbacks for Safes
+ * @title TokenCallbacks - ERC-1155 and ERC-721 token callbacks for Safes
  * @author mfw78 <mfw78@rndlabs.xyz>
  * @notice Refactored from https://github.com/safe-global/safe-contracts/blob/3c3fc80f7f9aef1d39aaae2b53db5f4490051b0d/contracts/handler/TokenCallbackHandler.sol
  */
 abstract contract TokenCallbacks is ExtensibleBase, ERC1155TokenReceiver, ERC721TokenReceiver {
     /**
-     * @notice Handles ERC1155 Token callback.
+     * @notice Handles ERC-1155 Token callback.
      * return Standardized onERC1155Received return value.
      */
-    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external pure override returns (bytes4) {
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external view override onlyFallback returns (bytes4) {
         // Else return the standard value
         return 0xf23a6e61;
     }
 
     /**
-     * @notice Handles ERC1155 Token batch callback.
+     * @notice Handles ERC-1155 Token batch callback.
      * return Standardized onERC1155BatchReceived return value.
      */
     function onERC1155BatchReceived(
@@ -31,16 +31,16 @@ abstract contract TokenCallbacks is ExtensibleBase, ERC1155TokenReceiver, ERC721
         uint256[] calldata,
         uint256[] calldata,
         bytes calldata
-    ) external pure override returns (bytes4) {
+    ) external view override onlyFallback returns (bytes4) {
         // Else return the standard value
         return 0xbc197c81;
     }
 
     /**
-     * @notice Handles ERC721 Token callback.
+     * @notice Handles ERC-721 Token callback.
      *  return Standardized onERC721Received return value.
      */
-    function onERC721Received(address, address, uint256, bytes calldata) external pure override returns (bytes4) {
+    function onERC721Received(address, address, uint256, bytes calldata) external view override onlyFallback returns (bytes4) {
         // Else return the standard value
         return 0x150b7a02;
     }

--- a/contracts/interfaces/ISafe.sol
+++ b/contracts/interfaces/ISafe.sol
@@ -6,12 +6,13 @@ import {IFallbackManager} from "./IFallbackManager.sol";
 import {IGuardManager} from "./IGuardManager.sol";
 import {IModuleManager} from "./IModuleManager.sol";
 import {IOwnerManager} from "./IOwnerManager.sol";
+import {IStorageAccessible} from "./IStorageAccessible.sol";
 
 /**
  * @title ISafe - A multisignature wallet interface with support for confirmations using signed messages based on EIP-712.
  * @author @safe-global/safe-protocol
  */
-interface ISafe is IModuleManager, IGuardManager, IOwnerManager, IFallbackManager {
+interface ISafe is IModuleManager, IGuardManager, IOwnerManager, IFallbackManager, IStorageAccessible {
     event SafeSetup(address indexed initiator, address[] owners, uint256 threshold, address initializer, address fallbackHandler);
     event ApproveHash(bytes32 indexed approvedHash, address indexed owner);
     event SignMsg(bytes32 indexed msgHash);

--- a/contracts/interfaces/IStorageAccessible.sol
+++ b/contracts/interfaces/IStorageAccessible.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.7.0 <0.9.0;
+
+/**
+ * @title Storage Accessible Interface
+ * @author @safe-global/safe-protocol
+ */
+interface IStorageAccessible {
+    /**
+     * @notice Reads `length` bytes of storage in the current contract
+     * @param offset The offset in the current contract's storage in words to start reading from.
+     * @param length The number of words (32 bytes) of data to read.
+     * @return The bytes that were read.
+     */
+    function getStorageAt(uint256 offset, uint256 length) external view returns (bytes memory);
+
+    /**
+     * @notice Performs a `DELEGATECALL` to a `targetContract` in the context of self.
+     * @dev Internally reverts execution to avoid side effects (making it effectively static).
+     *      This method reverts with data equal to `abi.encodePacked(uint256(success), uint256(response.length), bytes(response))`.
+     *      Specifically, the return data after a call to this method will be:
+     *      `success:uint256 || response.length:uint256 || response:bytes`.
+     * @param targetContract Address of the contract containing the code to execute.
+     * @param calldataPayload Calldata that should be sent to the target contract (encoded method name and arguments).
+     */
+    function simulateAndRevert(address targetContract, bytes memory calldataPayload) external;
+}

--- a/contracts/test/ERC721Token.sol
+++ b/contracts/test/ERC721Token.sol
@@ -1,21 +1,17 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {StorageAccessible} from "../common/StorageAccessible.sol";
 
 /**
- * @title ERC-1155 Test Token
+ * @title ERC-721 Test Token
  */
-contract ERC1155Token is ERC1155, StorageAccessible {
-    constructor() ERC1155("https://example.com") {}
+contract ERC721Token is ERC721, StorageAccessible {
+    constructor() ERC721("TestToken", "TT") {}
 
-    function mint(address to, uint256 id, uint256 value, bytes calldata data) external {
-        _mint(to, id, value, data);
-    }
-
-    function mintBatch(address to, uint256[] calldata ids, uint256[] calldata amounts, bytes calldata data) external {
-        _mintBatch(to, ids, amounts, data);
+    function mint(address to, uint256 token) external {
+        _mint(to, token);
     }
 
     function trickFallbackHandler(address fallbackHandler) external {

--- a/test/core/Safe.FallbackManager.spec.ts
+++ b/test/core/Safe.FallbackManager.spec.ts
@@ -107,13 +107,13 @@ describe("FallbackManager", () => {
 
             // Check unset callbacks
             // Ethers v6 throws an internal error when trying to call a non-existent function
-            await expect(safeHandler.onERC1155Received.staticCall(AddressZero, AddressZero, 0, 0, "0x")).to.be.rejected;
+            await expect(safeHandler.supportsInterface.staticCall("0x01ffc9a7")).to.be.rejected;
 
             // Setup Safe
             await safe.setup([user1.address, user2.address], 1, AddressZero, "0x", handler.address, AddressZero, 0, AddressZero);
 
             // Check callbacks
-            expect(await safeHandler.onERC1155Received.staticCall(AddressZero, AddressZero, 0, 0, "0x")).to.be.eq("0xf23a6e61");
+            expect(await safeHandler.supportsInterface.staticCall("0x01ffc9a7")).to.be.true;
         });
 
         it("sends along msg.sender on simple call", async () => {

--- a/test/handlers/CompatibilityFallbackHandler.spec.ts
+++ b/test/handlers/CompatibilityFallbackHandler.spec.ts
@@ -32,6 +32,8 @@ describe("CompatibilityFallbackHandler", () => {
         const validator = await getCompatFallbackHandler(safeAddress);
         const killLib = await killLibContract(user1, hre.network.zksync);
         const badSimulator = await badSimulatorContract(user1);
+        const erc721 = await ethers.deployContract("ERC721Token");
+        const erc1155 = await ethers.deployContract("ERC1155Token");
         return {
             safe,
             validator,
@@ -41,25 +43,93 @@ describe("CompatibilityFallbackHandler", () => {
             signLib,
             signerSafe,
             signers,
+            erc721,
+            erc1155,
         };
     });
 
     describe("ERC1155", () => {
         it("to handle onERC1155Received", async () => {
-            const { handler } = await setupTests();
-            await expect(await handler.onERC1155Received.staticCall(AddressZero, AddressZero, 0, 0, "0x")).to.be.eq("0xf23a6e61");
+            const { handler, safe } = await setupTests();
+            const result = await handler
+                .connect(ethers.provider)
+                .onERC1155Received(AddressZero, AddressZero, 0, 0, "0x", { from: await safe.getAddress() });
+            await expect(result).to.be.eq("0xf23a6e61");
         });
 
         it("to handle onERC1155BatchReceived", async () => {
-            const { handler } = await setupTests();
-            await expect(await handler.onERC1155BatchReceived.staticCall(AddressZero, AddressZero, [], [], "0x")).to.be.eq("0xbc197c81");
+            const { handler, safe } = await setupTests();
+            const result = await handler
+                .connect(ethers.provider)
+                .onERC1155BatchReceived(AddressZero, AddressZero, [], [], "0x", { from: await safe.getAddress() });
+            await expect(result).to.be.eq("0xbc197c81");
+        });
+
+        it("should allow a Safe to receive ERC-1155 tokens", async () => {
+            const {
+                safe,
+                signers: [user],
+                erc1155,
+            } = await setupTests();
+            await erc1155.mintBatch(await user.getAddress(), [1, 2, 3], [100, 100, 100], "0x");
+
+            await expect(erc1155.connect(user).safeTransferFrom(await user.getAddress(), await safe.getAddress(), 1, 100, "0x")).to.not.be
+                .reverted;
+            await expect(
+                erc1155.connect(user).safeBatchTransferFrom(await user.getAddress(), await safe.getAddress(), [2, 3], [100, 100], "0x"),
+            ).to.not.be.reverted;
+        });
+
+        it("should revert when tokens are transferred directly to the handler", async () => {
+            const {
+                handler,
+                signers: [user],
+                erc1155,
+            } = await setupTests();
+            await erc1155.mintBatch(await user.getAddress(), [1, 2, 3], [100, 100, 100], "0x");
+
+            await expect(erc1155.connect(user).safeTransferFrom(await user.getAddress(), await handler.getAddress(), 1, 100, "0x")).to.be
+                .reverted;
+            await expect(
+                erc1155.connect(user).safeBatchTransferFrom(await user.getAddress(), await handler.getAddress(), [2, 3], [100, 100], "0x"),
+            ).to.be.revertedWith("not a fallback call");
         });
     });
 
     describe("ERC721", () => {
         it("to handle onERC721Received", async () => {
-            const { handler } = await setupTests();
-            await expect(await handler.onERC721Received.staticCall(AddressZero, AddressZero, 0, "0x")).to.be.eq("0x150b7a02");
+            const { handler, safe } = await setupTests();
+
+            const result = await handler
+                .connect(ethers.provider)
+                .onERC721Received(AddressZero, AddressZero, 0, "0x", { from: await safe.getAddress() });
+            await expect(result).to.be.eq("0x150b7a02");
+        });
+
+        it("should allow a Safe to receive ERC-721 tokens", async () => {
+            const {
+                safe,
+                signers: [user],
+                erc721,
+            } = await setupTests();
+            await erc721.mint(await user.getAddress(), 1);
+
+            await expect(
+                erc721.connect(user)["safeTransferFrom(address,address,uint256)"](await user.getAddress(), await safe.getAddress(), 1),
+            ).to.not.be.reverted;
+        });
+
+        it("should revert when tokens are transferred directly to the handler", async () => {
+            const {
+                handler,
+                signers: [user],
+                erc721,
+            } = await setupTests();
+            await erc721.mint(await user.getAddress(), 1);
+
+            await expect(
+                erc721.connect(user)["safeTransferFrom(address,address,uint256)"](await user.getAddress(), await handler.getAddress(), 1),
+            ).to.be.revertedWith("not a fallback call");
         });
     });
 

--- a/test/handlers/TokenCallbackHandler.spec.ts
+++ b/test/handlers/TokenCallbackHandler.spec.ts
@@ -1,62 +1,149 @@
 import { expect } from "chai";
-import { deployments } from "hardhat";
+import { ethers, deployments } from "hardhat";
 import { AddressZero } from "@ethersproject/constants";
-import { getTokenCallbackHandler } from "../utils/setup";
+import { getSafe, getTokenCallbackHandler } from "../utils/setup";
 
 describe("TokenCallbackHandler", () => {
-    beforeEach(async () => {
+    const setupTests = deployments.createFixture(async () => {
         await deployments.fixture();
+
+        const handler = await getTokenCallbackHandler();
+        const [user] = await ethers.getSigners();
+        const safe = await getSafe({ owners: [user.address], threshold: 1, fallbackHandler: await handler.getAddress() });
+
+        const erc721 = await ethers.deployContract("ERC721Token");
+        const erc1155 = await ethers.deployContract("ERC1155Token");
+
+        return { handler, user, safe, erc721, erc1155 };
     });
 
     describe("ERC1155", () => {
         it("should support ERC1155 interface", async () => {
-            const handler = await getTokenCallbackHandler();
+            const { handler } = await setupTests();
             await expect(await handler.supportsInterface.staticCall("0x4e2312e0")).to.be.eq(true);
         });
 
         it("to handle onERC1155Received", async () => {
-            const handler = await getTokenCallbackHandler();
-            await expect(await handler.onERC1155Received.staticCall(AddressZero, AddressZero, 0, 0, "0x")).to.be.eq("0xf23a6e61");
+            const { handler, safe } = await setupTests();
+            const result = await handler
+                .connect(ethers.provider)
+                .onERC1155Received(AddressZero, AddressZero, 0, 0, "0x", { from: await safe.getAddress() });
+            await expect(result).to.be.eq("0xf23a6e61");
         });
 
         it("to handle onERC1155BatchReceived", async () => {
-            const handler = await getTokenCallbackHandler();
-            await expect(await handler.onERC1155BatchReceived.staticCall(AddressZero, AddressZero, [], [], "0x")).to.be.eq("0xbc197c81");
+            const { handler, safe } = await setupTests();
+            const result = await handler
+                .connect(ethers.provider)
+                .onERC1155BatchReceived(AddressZero, AddressZero, [], [], "0x", { from: await safe.getAddress() });
+            await expect(result).to.be.eq("0xbc197c81");
+        });
+
+        it("should allow a Safe to receive ERC-1155 tokens", async () => {
+            const { safe, user, erc1155 } = await setupTests();
+            await erc1155.mintBatch(await user.getAddress(), [1, 2, 3], [100, 100, 100], "0x");
+
+            await expect(erc1155.connect(user).safeTransferFrom(await user.getAddress(), await safe.getAddress(), 1, 100, "0x")).to.not.be
+                .reverted;
+            await expect(
+                erc1155.connect(user).safeBatchTransferFrom(await user.getAddress(), await safe.getAddress(), [2, 3], [100, 100], "0x"),
+            ).to.not.be.reverted;
+        });
+
+        it("should revert when tokens are transferred directly to the handler", async () => {
+            const { handler, user, erc1155 } = await setupTests();
+            await erc1155.mintBatch(await user.getAddress(), [1, 2, 3], [100, 100, 100], "0x");
+
+            await expect(
+                erc1155.connect(user).safeTransferFrom(await user.getAddress(), await handler.getAddress(), 1, 100, "0x"),
+            ).to.be.revertedWith("not a fallback call");
+            await expect(
+                erc1155.connect(user).safeBatchTransferFrom(await user.getAddress(), await handler.getAddress(), [2, 3], [100, 100], "0x"),
+            ).to.be.revertedWith("not a fallback call");
+        });
+
+        it("can be tricked into sending tokens to the fallback handler", async () => {
+            // demonstrate that the `onERC*Received` methods are best effort, and that they can be
+            // tricked to send tokens to the fallback handler.
+            const { handler, user, erc1155 } = await setupTests();
+
+            await erc1155.mint(await user.getAddress(), 1, 100, "0x");
+            await erc1155.trickFallbackHandler(await handler.getAddress());
+
+            await expect(erc1155.connect(user).safeTransferFrom(await user.getAddress(), await handler.getAddress(), 1, 100, "0x")).to.not
+                .be.reverted;
         });
     });
 
     describe("ERC721", () => {
         it("should support ERC721 interface", async () => {
-            const handler = await getTokenCallbackHandler();
+            const { handler } = await setupTests();
             await expect(await handler.supportsInterface.staticCall("0x150b7a02")).to.be.eq(true);
         });
 
         it("to handle onERC721Received", async () => {
-            const handler = await getTokenCallbackHandler();
-            await expect(await handler.onERC721Received.staticCall(AddressZero, AddressZero, 0, "0x")).to.be.eq("0x150b7a02");
+            const { handler, safe } = await setupTests();
+
+            const result = await handler
+                .connect(ethers.provider)
+                .onERC721Received(AddressZero, AddressZero, 0, "0x", { from: await safe.getAddress() });
+            await expect(result).to.be.eq("0x150b7a02");
+        });
+
+        it("should allow a Safe to receive ERC-721 tokens", async () => {
+            const { safe, user, erc721 } = await setupTests();
+            await erc721.mint(await user.getAddress(), 1);
+
+            await expect(
+                erc721.connect(user)["safeTransferFrom(address,address,uint256)"](await user.getAddress(), await safe.getAddress(), 1),
+            ).to.not.be.reverted;
+        });
+
+        it("should revert when tokens are transferred directly to the handler", async () => {
+            const { handler, user, erc721 } = await setupTests();
+            await erc721.mint(await user.getAddress(), 1);
+
+            await expect(
+                erc721.connect(user)["safeTransferFrom(address,address,uint256)"](await user.getAddress(), await handler.getAddress(), 1),
+            ).to.be.revertedWith("not a fallback call");
+        });
+
+        it("can be tricked into sending tokens to the fallback handler", async () => {
+            // demonstrate that the `onERC*Received` methods are best effort, and that they can be
+            // tricked to send tokens to the fallback handler.
+            const { handler, user, erc721 } = await setupTests();
+
+            await erc721.mint(await user.getAddress(), 1);
+            await erc721.trickFallbackHandler(await handler.getAddress());
+
+            await expect(
+                erc721
+                    .connect(user)
+                    ["safeTransferFrom(address,address,uint256,bytes)"](await user.getAddress(), await handler.getAddress(), 1, "0x"),
+            ).to.not.be.reverted;
         });
     });
 
     describe("ERC777", () => {
         it("to handle tokensReceived", async () => {
-            const handler = await getTokenCallbackHandler();
+            const { handler } = await setupTests();
             await handler.tokensReceived.staticCall(AddressZero, AddressZero, AddressZero, 0, "0x", "0x");
         });
     });
 
     describe("ERC165", () => {
         it("should support ERC165 interface", async () => {
-            const handler = await getTokenCallbackHandler();
+            const { handler } = await setupTests();
             await expect(await handler.supportsInterface.staticCall("0x01ffc9a7")).to.be.eq(true);
         });
 
         it("should not support random interface", async () => {
-            const handler = await getTokenCallbackHandler();
+            const { handler } = await setupTests();
             await expect(await handler.supportsInterface.staticCall("0xbaddad42")).to.be.eq(false);
         });
 
         it("should not support invalid interface", async () => {
-            const handler = await getTokenCallbackHandler();
+            const { handler } = await setupTests();
             await expect(await handler.supportsInterface.staticCall("0xffffffff")).to.be.eq(false);
         });
     });


### PR DESCRIPTION
This PR changes the implementation of `TokenCallbackHandler` and `TokenCallbacks` to make a best-effort check on whether the tokens were sent to a Safe that configures a token callback handler contract as a fallback handler, or if it sent to the fallback handler contract itself directly.

Thanks @remedcu and @rmeissner for the suggestions on how to implement it! Basically, it works calling the `msg.sender` and expecting it to be a Safe configured with the fallback handler. This would either:

- Fail if the token doesn't implement `StorageAccessible`
- Fail if the token doesn't have the specific `FALLBACK_HANDLER_SLOT` set to the actual fallback handler

Note, however, that it is possible to trick the fallback handler into receiving tokens. Because of this, we document that the checks are best-effort only! We add a test to document how the fallback handler can be tricked.