### PR TITLE
Ackee[I2]: Make `ISafe` Payable

### DIFF
--- a/contracts/common/NativeCurrencyPaymentFallback.sol
+++ b/contracts/common/NativeCurrencyPaymentFallback.sol
@@ -1,18 +1,17 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
+import {INativeCurrencyPaymentFallback} from "./../interfaces/INativeCurrencyPaymentFallback.sol";
+
 /**
  * @title NativeCurrencyPaymentFallback - A contract that has a fallback to accept native currency payments.
  * @author Richard Meissner - @rmeissner
  */
-abstract contract NativeCurrencyPaymentFallback {
-    event SafeReceived(address indexed sender, uint256 value);
-
+abstract contract NativeCurrencyPaymentFallback is INativeCurrencyPaymentFallback {
     /**
-     * @notice Receive function accepts native currency transactions.
-     * @dev Emits an event with sender and received value.
+     * @inheritdoc INativeCurrencyPaymentFallback
      */
-    receive() external payable {
+    receive() external payable override {
         emit SafeReceived(msg.sender, msg.value);
     }
 }

--- a/contracts/examples/guards/OnlyOwnersGuard.sol
+++ b/contracts/examples/guards/OnlyOwnersGuard.sol
@@ -38,7 +38,7 @@ contract OnlyOwnersGuard is BaseTransactionGuard {
         bytes memory,
         address msgSender
     ) external view override {
-        require(ISafe(msg.sender).isOwner(msgSender), "msg sender is not allowed to exec");
+        require(ISafe(payable(msg.sender)).isOwner(msgSender), "msg sender is not allowed to exec");
     }
 
     /**

--- a/contracts/interfaces/INativeCurrencyPaymentFallback.sol
+++ b/contracts/interfaces/INativeCurrencyPaymentFallback.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.7.0 <0.9.0;
+
+/**
+ * @title Native Currency Payment Fallback Interface
+ * @notice An interface to a contract that can receive native currency payments.
+ * @author @safe-global/safe-protocol
+ */
+interface INativeCurrencyPaymentFallback {
+    event SafeReceived(address indexed sender, uint256 value);
+
+    /**
+     * @notice Receive function accepts native currency transactions.
+     * @dev Emits an event with sender and received value.
+     */
+    receive() external payable;
+}

--- a/contracts/interfaces/ISafe.sol
+++ b/contracts/interfaces/ISafe.sol
@@ -5,6 +5,7 @@ import {Enum} from "./../libraries/Enum.sol";
 import {IFallbackManager} from "./IFallbackManager.sol";
 import {IGuardManager} from "./IGuardManager.sol";
 import {IModuleManager} from "./IModuleManager.sol";
+import {INativeCurrencyPaymentFallback} from "./INativeCurrencyPaymentFallback.sol";
 import {IOwnerManager} from "./IOwnerManager.sol";
 import {IStorageAccessible} from "./IStorageAccessible.sol";
 
@@ -12,7 +13,7 @@ import {IStorageAccessible} from "./IStorageAccessible.sol";
  * @title ISafe - A multisignature wallet interface with support for confirmations using signed messages based on EIP-712.
  * @author @safe-global/safe-protocol
  */
-interface ISafe is IModuleManager, IGuardManager, IOwnerManager, IFallbackManager, IStorageAccessible {
+interface ISafe is INativeCurrencyPaymentFallback, IModuleManager, IGuardManager, IOwnerManager, IFallbackManager, IStorageAccessible {
     event SafeSetup(address indexed initiator, address[] owners, uint256 threshold, address initializer, address fallbackHandler);
     event ApproveHash(bytes32 indexed approvedHash, address indexed owner);
     event SignMsg(bytes32 indexed msgHash);

--- a/contracts/libraries/SafeMigration.sol
+++ b/contracts/libraries/SafeMigration.sol
@@ -79,7 +79,7 @@ contract SafeMigration is SafeStorage {
      */
     function migrateWithFallbackHandler() external onlyDelegateCall {
         migrateSingleton();
-        ISafe(address(this)).setFallbackHandler(SAFE_FALLBACK_HANDLER);
+        ISafe(payable(address(this))).setFallbackHandler(SAFE_FALLBACK_HANDLER);
     }
 
     /**
@@ -96,7 +96,7 @@ contract SafeMigration is SafeStorage {
      */
     function migrateL2WithFallbackHandler() external onlyDelegateCall {
         migrateL2Singleton();
-        ISafe(address(this)).setFallbackHandler(SAFE_FALLBACK_HANDLER);
+        ISafe(payable(address(this))).setFallbackHandler(SAFE_FALLBACK_HANDLER);
     }
 
     /**

--- a/contracts/libraries/SafeToL2Migration.sol
+++ b/contracts/libraries/SafeToL2Migration.sol
@@ -110,8 +110,8 @@ contract SafeToL2Migration is SafeStorage {
     function migrateToL2(address l2Singleton) external onlyDelegateCall onlyNonceZero {
         address _singleton = singleton;
         require(_singleton != l2Singleton, "Safe is already using the singleton");
-        bytes32 oldSingletonVersion = keccak256(abi.encodePacked(ISafe(_singleton).VERSION()));
-        bytes32 newSingletonVersion = keccak256(abi.encodePacked(ISafe(l2Singleton).VERSION()));
+        bytes32 oldSingletonVersion = keccak256(abi.encodePacked(ISafe(payable(_singleton)).VERSION()));
+        bytes32 newSingletonVersion = keccak256(abi.encodePacked(ISafe(payable(l2Singleton)).VERSION()));
 
         require(oldSingletonVersion == newSingletonVersion, "L2 singleton must match current version singleton");
         // There's no way to make sure if address is a valid singleton, unless we configure the contract for every chain
@@ -133,16 +133,16 @@ contract SafeToL2Migration is SafeStorage {
     function migrateFromV111(address l2Singleton, address fallbackHandler) external onlyDelegateCall onlyNonceZero {
         require(isContract(fallbackHandler), "fallbackHandler is not a contract");
 
-        bytes32 oldSingletonVersion = keccak256(abi.encodePacked(ISafe(singleton).VERSION()));
+        bytes32 oldSingletonVersion = keccak256(abi.encodePacked(ISafe(payable(singleton)).VERSION()));
         require(oldSingletonVersion == keccak256(abi.encodePacked("1.1.1")), "Provided singleton version is not supported");
 
-        bytes32 newSingletonVersion = keccak256(abi.encodePacked(ISafe(l2Singleton).VERSION()));
+        bytes32 newSingletonVersion = keccak256(abi.encodePacked(ISafe(payable(l2Singleton)).VERSION()));
         require(
             newSingletonVersion == keccak256(abi.encodePacked("1.3.0")) || newSingletonVersion == keccak256(abi.encodePacked("1.4.1")),
             "Provided singleton version is not supported"
         );
 
-        ISafe safe = ISafe(address(this));
+        ISafe safe = ISafe(payable(address(this)));
         safe.setFallbackHandler(fallbackHandler);
 
         // Safes < 1.3.0 did not emit SafeSetup, so Safe Tx Service backend needs the event to index the Safe

--- a/contracts/test/Test4337ModuleAndHandler.sol
+++ b/contracts/test/Test4337ModuleAndHandler.sol
@@ -56,6 +56,6 @@ contract Test4337ModuleAndHandler {
     }
 
     function enableMyself() public {
-        ISafe(address(this)).enableModule(MY_ADDRESS);
+        ISafe(payable(address(this))).enableModule(MY_ADDRESS);
     }
 }


### PR DESCRIPTION
`ISafe` interface was not payable, but it should be as the `Safe` can receive tokens. This PR adds a `INativeCurrencyPaymentFallback` interface with a payable `receive` function and makes the `ISafe` interface inherit from it. This makes the `ISafe` interface payable, and requires addresses that are cast to it to also be `payable`.