### PR TITLE
Ackee[I4]: Propagate Revert on Failed Initialization

### DIFF
--- a/contracts/proxies/SafeProxyFactory.sol
+++ b/contracts/proxies/SafeProxyFactory.sol
@@ -41,7 +41,9 @@ contract SafeProxyFactory {
             /// @solidity memory-safe-assembly
             assembly {
                 if iszero(call(gas(), proxy, 0, add(initializer, 0x20), mload(initializer), 0, 0)) {
-                    revert(0, 0)
+                    let ptr := mload(0x40)
+                    returndatacopy(ptr, 0x00, returndatasize())
+                    revert(ptr, returndatasize())
                 }
             }
             /* solhint-enable no-inline-assembly */

--- a/test/factory/ProxyFactory.spec.ts
+++ b/test/factory/ProxyFactory.spec.ts
@@ -22,6 +22,10 @@ describe("ProxyFactory", () => {
             isInitialized = true;
         }
 
+        function revertingInitializer() public {
+            revert("initilalization reverted");
+        }
+
         function masterCopy() public pure returns (address) {
             return address(0);
         }
@@ -107,6 +111,15 @@ describe("ProxyFactory", () => {
                 .withArgs(proxyAddress, singletonAddress);
             await expect(factory.createProxyWithNonce(singletonAddress, initCode, saltNonce)).to.be.revertedWith("Create2 call failed");
         });
+
+        it("should propagate initializer reverts", async () => {
+            const { factory, singleton } = await setupTests();
+            const singletonAddress = await singleton.getAddress();
+            const initCode = singleton.interface.encodeFunctionData("revertingInitializer", []);
+            await expect(factory.createProxyWithNonce(singletonAddress, initCode, saltNonce)).to.be.revertedWith(
+                "initilalization reverted",
+            );
+        });
     });
 
     describe("createProxyWithNonceL2", () => {
@@ -177,6 +190,15 @@ describe("ProxyFactory", () => {
                 .to.emit(factory, "ProxyCreationL2")
                 .withArgs(proxyAddress, singletonAddress, initCode, saltNonce);
             await expect(factory.createProxyWithNonceL2(singletonAddress, initCode, saltNonce)).to.be.revertedWith("Create2 call failed");
+        });
+
+        it("should propagate initializer reverts", async () => {
+            const { factory, singleton } = await setupTests();
+            const singletonAddress = await singleton.getAddress();
+            const initCode = singleton.interface.encodeFunctionData("revertingInitializer", []);
+            await expect(factory.createProxyWithNonceL2(singletonAddress, initCode, saltNonce)).to.be.revertedWith(
+                "initilalization reverted",
+            );
         });
     });
 


### PR DESCRIPTION
This PR modifies the proxy factory such that it propagates the revert from failed initializations in order to facilitate debugging.