### PR TITLE
Ackee[I7]: Mark Contracts As Abstract

### DIFF
--- a/contracts/interfaces/ISignatureValidator.sol
+++ b/contracts/interfaces/ISignatureValidator.sol
@@ -2,7 +2,7 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity >=0.7.0 <0.9.0;
 
-contract ISignatureValidatorConstants {
+abstract contract ISignatureValidatorConstants {
     // bytes4(keccak256("isValidSignature(bytes32,bytes)")
     bytes4 internal constant EIP1271_MAGIC_VALUE = 0x1626ba7e;
 }

--- a/contracts/libraries/SafeStorage.sol
+++ b/contracts/libraries/SafeStorage.sol
@@ -6,7 +6,7 @@ pragma solidity >=0.7.0 <0.9.0;
  * @dev Should be always the first base contract of a library that is used with a Safe.
  * @author Richard Meissner - @rmeissner
  */
-contract SafeStorage {
+abstract contract SafeStorage {
     // From /common/Singleton.sol
     address internal singleton;
     // From /common/ModuleManager.sol


### PR DESCRIPTION
The `SafeStorage` and `SignatureValidatorConstants` can both be marked as abstract in order to better reflect their intended usage.