### PR TITLE
Ackee[W1]: Less Confusing Event Emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,9 @@ The repository was renamed from `safe-contracts` to `safe-smart-account` to bett
 
 PR: [#851](https://github.com/safe-global/safe-smart-account/pull/851)
 
-`ExtensibleFallbackHandler` originally created by the CoWSwap Team is used for bringing new features and capabilities to Safe Smart Account including, but not limited to swaps, TWAP orders, etc. More details can be found [here](https://cow.fi/learn/all-you-need-to-know-about-cow-swap-new-safe-fallback-handler).
+`ExtensibleFallbackHandler` originally created by the CoW Swap team is used for bringing new features and capabilities to Safe Smart Account including, but not limited to swaps, TWAP orders, etc. More details can be found [here](https://cow.fi/learn/all-you-need-to-know-about-cow-swap-new-safe-fallback-handler).
+
+**NOTE**: The events for adding and removing Safe methods and domain verifiers were simplified such that contracts only emit a "changed" event. This is a breaking change from the original implementation from the CoW Swap team.
 
 #### Event emitted with `initializer` and `saltNonce` for proxy creation
 

--- a/contracts/handler/extensible/SignatureVerifierMuxer.sol
+++ b/contracts/handler/extensible/SignatureVerifierMuxer.sol
@@ -64,14 +64,12 @@ abstract contract SignatureVerifierMuxer is ExtensibleBase, ERC1271, ISignatureV
     mapping(ISafe => mapping(bytes32 => ISafeSignatureVerifier)) public override domainVerifiers;
 
     // --- events ---
-    event AddedDomainVerifier(ISafe indexed safe, bytes32 domainSeparator, ISafeSignatureVerifier verifier);
     event ChangedDomainVerifier(
         ISafe indexed safe,
         bytes32 domainSeparator,
         ISafeSignatureVerifier oldVerifier,
         ISafeSignatureVerifier newVerifier
     );
-    event RemovedDomainVerifier(ISafe indexed safe, bytes32 domainSeparator);
 
     /**
      * Setter for the signature muxer
@@ -81,17 +79,8 @@ abstract contract SignatureVerifierMuxer is ExtensibleBase, ERC1271, ISignatureV
     function setDomainVerifier(bytes32 domainSeparator, ISafeSignatureVerifier newVerifier) public override onlySelf {
         ISafe safe = ISafe(payable(_msgSender()));
         ISafeSignatureVerifier oldVerifier = domainVerifiers[safe][domainSeparator];
-        if (address(newVerifier) == address(0) && address(oldVerifier) != address(0)) {
-            delete domainVerifiers[safe][domainSeparator];
-            emit RemovedDomainVerifier(safe, domainSeparator);
-        } else {
-            domainVerifiers[safe][domainSeparator] = newVerifier;
-            if (address(oldVerifier) == address(0)) {
-                emit AddedDomainVerifier(safe, domainSeparator, newVerifier);
-            } else {
-                emit ChangedDomainVerifier(safe, domainSeparator, oldVerifier, newVerifier);
-            }
-        }
+        domainVerifiers[safe][domainSeparator] = newVerifier;
+        emit ChangedDomainVerifier(safe, domainSeparator, oldVerifier, newVerifier);
     }
 
     /**

--- a/test/handlers/ExtensibleFallbackHandler.spec.ts
+++ b/test/handlers/ExtensibleFallbackHandler.spec.ts
@@ -190,8 +190,8 @@ describe("ExtensibleFallbackHandler", () => {
                 const safeAddress = await safe.getAddress();
                 const newHandler = encodeHandler(true, await mirror.getAddress());
                 await expect(executeContractCallWithSigners(safe, validator, "setSafeMethod", ["0xdededede", newHandler], [user1, user2]))
-                    .to.emit(handler, "AddedSafeMethod")
-                    .withArgs(safeAddress, "0xdededede", newHandler.toLowerCase());
+                    .to.emit(handler, "ChangedSafeMethod")
+                    .withArgs(safeAddress, "0xdededede", HashZero, newHandler.toLowerCase());
 
                 // Check that the method is actually set
                 expect(await handler.safeMethods.staticCall(safeAddress, "0xdededede")).to.be.eq(newHandler);
@@ -219,8 +219,9 @@ describe("ExtensibleFallbackHandler", () => {
             });
 
             it("should emit event when removing a method", async () => {
-                const { user1, user2, otherSafe, handler, preconfiguredValidator } = await setupTests();
+                const { user1, user2, otherSafe, handler, preconfiguredValidator, mirror } = await setupTests();
                 const otherSafeAddress = await otherSafe.getAddress();
+                const oldHandler = encodeHandler(true, await mirror.getAddress());
                 await expect(
                     executeContractCallWithSigners(
                         otherSafe,
@@ -230,8 +231,8 @@ describe("ExtensibleFallbackHandler", () => {
                         [user1, user2],
                     ),
                 )
-                    .to.emit(handler, "RemovedSafeMethod")
-                    .withArgs(otherSafeAddress, "0x7f8dc53c");
+                    .to.emit(handler, "ChangedSafeMethod")
+                    .withArgs(otherSafeAddress, "0x7f8dc53c", oldHandler, HashZero);
 
                 // Check that the method is actually removed
                 expect(await handler.safeMethods.staticCall(otherSafeAddress, "0x7f8dc53c")).to.be.eq(HashZero);
@@ -390,8 +391,8 @@ describe("ExtensibleFallbackHandler", () => {
                         [user1, user2],
                     ),
                 )
-                    .to.emit(handler, "AddedDomainVerifier")
-                    .withArgs(safeAddress, domainSeparator, testVerifierAddress);
+                    .to.emit(handler, "ChangedDomainVerifier")
+                    .withArgs(safeAddress, domainSeparator, ethers.ZeroAddress, testVerifierAddress);
 
                 expect(await handler.domainVerifiers(safeAddress, domainSeparator)).to.be.eq(testVerifierAddress);
             });
@@ -422,6 +423,8 @@ describe("ExtensibleFallbackHandler", () => {
                 const { user1, user2, otherSafe, handler, preconfiguredValidator } = await setupTests();
                 const otherSafeAddress = await otherSafe.getAddress();
                 const domainSeparator = ethers.keccak256("0xdeadbeef");
+                const oldVerifier = await handler.domainVerifiers(otherSafeAddress, domainSeparator);
+
                 await expect(
                     executeContractCallWithSigners(
                         otherSafe,
@@ -431,8 +434,8 @@ describe("ExtensibleFallbackHandler", () => {
                         [user1, user2],
                     ),
                 )
-                    .to.emit(handler, "RemovedDomainVerifier")
-                    .withArgs(otherSafeAddress, domainSeparator);
+                    .to.emit(handler, "ChangedDomainVerifier")
+                    .withArgs(otherSafeAddress, domainSeparator, oldVerifier, ethers.ZeroAddress);
 
                 expect(await handler.domainVerifiers(otherSafeAddress, domainSeparator)).to.be.eq(AddressZero);
             });
@@ -721,12 +724,12 @@ describe("ExtensibleFallbackHandler", () => {
                 await expect(
                     executeContractCallWithSigners(safe, validator, "addSupportedInterfaceBatch", [interfaceId, batch], [user1, user2]),
                 )
-                    .to.emit(handler, "AddedSafeMethod")
-                    .withArgs(safeAddress, "0xabababab", encodeHandler(true, mirrorAddress))
-                    .to.emit(handler, "AddedSafeMethod")
-                    .withArgs(safeAddress, "0xcdcdcdcd", encodeHandler(true, mirrorAddress))
-                    .to.emit(handler, "AddedSafeMethod")
-                    .withArgs(safeAddress, "0xefefefef", encodeHandler(true, mirrorAddress))
+                    .to.emit(handler, "ChangedSafeMethod")
+                    .withArgs(safeAddress, "0xabababab", HashZero, encodeHandler(true, mirrorAddress))
+                    .to.emit(handler, "ChangedSafeMethod")
+                    .withArgs(safeAddress, "0xcdcdcdcd", HashZero, encodeHandler(true, mirrorAddress))
+                    .to.emit(handler, "ChangedSafeMethod")
+                    .withArgs(safeAddress, "0xefefefef", HashZero, encodeHandler(true, mirrorAddress))
                     .to.emit(handler, "AddedInterface")
                     .withArgs(safeAddress, interfaceId);
 
@@ -762,12 +765,12 @@ describe("ExtensibleFallbackHandler", () => {
                 await expect(
                     executeContractCallWithSigners(safe, validator, "addSupportedInterfaceBatch", [interfaceId, batch], [user1, user2]),
                 )
-                    .to.emit(handler, "AddedSafeMethod")
-                    .withArgs(safeAddress, "0xabababab", encodeHandler(true, mirrorAddress))
-                    .to.emit(handler, "AddedSafeMethod")
-                    .withArgs(safeAddress, "0xcdcdcdcd", encodeHandler(true, mirrorAddress))
-                    .to.emit(handler, "AddedSafeMethod")
-                    .withArgs(safeAddress, "0xefefefef", encodeHandler(true, mirrorAddress))
+                    .to.emit(handler, "ChangedSafeMethod")
+                    .withArgs(safeAddress, "0xabababab", HashZero, encodeHandler(true, mirrorAddress))
+                    .to.emit(handler, "ChangedSafeMethod")
+                    .withArgs(safeAddress, "0xcdcdcdcd", HashZero, encodeHandler(true, mirrorAddress))
+                    .to.emit(handler, "ChangedSafeMethod")
+                    .withArgs(safeAddress, "0xefefefef", HashZero, encodeHandler(true, mirrorAddress))
                     .to.emit(handler, "AddedInterface")
                     .withArgs(safeAddress, interfaceId);
 
@@ -795,12 +798,12 @@ describe("ExtensibleFallbackHandler", () => {
                         [user1, user2],
                     ),
                 )
-                    .to.emit(handler, "RemovedSafeMethod")
-                    .withArgs(safeAddress, "0xabababab")
-                    .to.emit(handler, "RemovedSafeMethod")
-                    .withArgs(safeAddress, "0xcdcdcdcd")
-                    .to.emit(handler, "RemovedSafeMethod")
-                    .withArgs(safeAddress, "0xefefefef")
+                    .to.emit(handler, "ChangedSafeMethod")
+                    .withArgs(safeAddress, "0xabababab", encodeHandler(true, mirrorAddress), HashZero)
+                    .to.emit(handler, "ChangedSafeMethod")
+                    .withArgs(safeAddress, "0xcdcdcdcd", encodeHandler(true, mirrorAddress), HashZero)
+                    .to.emit(handler, "ChangedSafeMethod")
+                    .withArgs(safeAddress, "0xefefefef", encodeHandler(true, mirrorAddress), HashZero)
                     .to.emit(handler, "RemovedInterface")
                     .withArgs(safeAddress, interfaceId);
 


### PR DESCRIPTION
We simplified the `ExtensibleFallbackHandler` to use a single event, instead of selecting an event depending on the parameters. This makes the events more consistent with the other Safe contract events, namely:

- We roughly emit one event per method (so, `setFallbackHandler` or `setGuard` also do not distinguish between enabling and disabling, while `addOwner` and `removeOwner` do)
- We consistently emit an event regardless of whether or not the storage actually changed.