### PR TITLE
chore(ci): update setup-python to v5

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -21,7 +21,7 @@ jobs:
             - uses: actions/checkout@v4
 
             - name: Install python
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with: { python-version: 3.11 }
 
             - name: Install certora cli


### PR DESCRIPTION
### Description
PR updates the GitHub Action `actions/setup-python` from `v4` to `v5` to ensure compatibility with the latest features and improvements.  
Python version `3.11` remains unchanged, as it is still officially supported by the action.

Reference: https://github.com/actions/setup-python/releases