### PR TITLE
Pin Anvil ZKSync Version

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -94,6 +94,11 @@ const userConfig: HardhatUserConfig = {
             suppressedErrors: ["assemblycreate"],
         },
     },
+    zksyncAnvil: {
+        // the zksync tests fail with version 0.6.4
+        // in general, it's good to pin zksync version because semver doesn't apply to 0.x releases
+        version: "0.6.3",
+    },
     networks: {
         hardhat: {
             allowUnlimitedContractSize: true,


### PR DESCRIPTION
Thanks to @mmv08 for figuring this out!

## LLM Description
This pull request introduces a configuration update to the `hardhat.config.ts` file. The most important change is the addition of a `zksyncAnvil` configuration to pin the `zksync` version to `0.6.3`, ensuring compatibility and stability for tests.

Configuration update:

* [`hardhat.config.ts`](diffhunk://#diff-57cf5378f8cab20b02b279097ba6fad08eb53f747d81770045dda9c5f95effe3R97-R101): Added a `zksyncAnvil` configuration block with the `version` field set to `0.6.3`. This change addresses compatibility issues with version `0.6.4` and follows best practices for pinning versions of `zksync` due to the lack of semver guarantees in `0.x` releases.