### PR TITLE
Docs: Update the `IModuleManager` and `IOwnerManager` interfaces to clarify the usage of the `prevModule` and `prevOwner` 

### DIFF
--- a/contracts/interfaces/IModuleManager.sol
+++ b/contracts/interfaces/IModuleManager.sol
@@ -27,7 +27,10 @@ interface IModuleManager {
     /**
      * @notice Disables the module `module` for the Safe.
      * @dev This can only be done via a Safe transaction.
-     * @param prevModule Previous module in the modules linked list.
+     * @param prevModule Previous module in the modules linked list. If the module to be
+     *        disabled is the first (or only) element of the list, `prevModule` MUST be
+     *        set to the sentinel address `0x1` (referred to as `SENTINEL_MODULES` in the
+     *        implementation).
      * @param module Module to be removed.
      */
     function disableModule(address prevModule, address module) external;

--- a/contracts/interfaces/IOwnerManager.sol
+++ b/contracts/interfaces/IOwnerManager.sol
@@ -21,7 +21,10 @@ interface IOwnerManager {
     /**
      * @notice Removes the owner `owner` from the Safe and updates the threshold to `_threshold`.
      * @dev This can only be done via a Safe transaction.
-     * @param prevOwner Owner that pointed to the owner to be removed in the linked list
+     * @param prevOwner Owner that pointed to the owner to be removed in the linked list.
+     *        If the owner to be removed is the first (or only) element of the list,
+     *        `prevOwner` MUST be set to the sentinel address `0x1` (referred to as
+     *        `SENTINEL_OWNERS` in the implementation).
      * @param owner Owner address to be removed.
      * @param _threshold New threshold.
      */
@@ -30,7 +33,10 @@ interface IOwnerManager {
     /**
      * @notice Replaces the owner `oldOwner` in the Safe with `newOwner`.
      * @dev This can only be done via a Safe transaction.
-     * @param prevOwner Owner that pointed to the owner to be replaced in the linked list
+     * @param prevOwner Owner that pointed to the owner to be replaced in the linked list.
+     *        If the owner to be replaced is the first (or only) element of the list,
+     *        `prevOwner` MUST be set to the sentinel address `0x1` (referred to as
+     *        `SENTINEL_OWNERS` in the implementation).
      * @param oldOwner Owner address to be replaced.
      * @param newOwner New owner address.
      */

--- a/contracts/interfaces/IOwnerManager.sol
+++ b/contracts/interfaces/IOwnerManager.sol
@@ -33,7 +33,7 @@ interface IOwnerManager {
     /**
      * @notice Replaces the owner `oldOwner` in the Safe with `newOwner`.
      * @dev This can only be done via a Safe transaction.
-     * @param prevOwner Owner that pointed to the owner to be replaced in the linked list.
+     * @param prevOwner Owner that pointed to the `oldOwner` to be replaced in the linked list.
      *        If the owner to be replaced is the first (or only) element of the list,
      *        `prevOwner` MUST be set to the sentinel address `0x1` (referred to as
      *        `SENTINEL_OWNERS` in the implementation).

--- a/contracts/interfaces/IOwnerManager.sol
+++ b/contracts/interfaces/IOwnerManager.sol
@@ -21,7 +21,7 @@ interface IOwnerManager {
     /**
      * @notice Removes the owner `owner` from the Safe and updates the threshold to `_threshold`.
      * @dev This can only be done via a Safe transaction.
-     * @param prevOwner Owner that pointed to the owner to be removed in the linked list.
+     * @param prevOwner Owner that pointed to the `owner` to be removed in the linked list.
      *        If the owner to be removed is the first (or only) element of the list,
      *        `prevOwner` MUST be set to the sentinel address `0x1` (referred to as
      *        `SENTINEL_OWNERS` in the implementation).


### PR DESCRIPTION
Updated the `IModuleManager` and `IOwnerManager` interfaces to clarify the usage of the `prevModule` and `prevOwner` parameters in the `disableModule` and `removeOwner` functions. Added details specifying that when the module or owner to be removed is the first (or only) element in the list, the respective `prevModule` or `prevOwner` must be set to the sentinel address `0x1`. This improves understanding of the linked list structure used in these functions.

fixes https://github.com/safe-global/safe-smart-account/issues/992