### PR TITLE
Allow Safe to Own Itself

### DIFF
--- a/certora/specs/OwnerReach.spec
+++ b/certora/specs/OwnerReach.spec
@@ -57,18 +57,6 @@ invariant thresholdSet() getThreshold() > 0  && getThreshold() <= ghostOwnerCoun
         }
     }
 
-invariant self_not_owner() currentContract != SENTINEL => ghostOwners[currentContract] == 0
-    filtered { f -> reachableOnly(f) }
-    {
-        preserved {
-            requireInvariant reach_null();
-            requireInvariant reach_invariant();
-            requireInvariant inListReachable();
-            requireInvariant reachableInList();
-            requireInvariant thresholdSet();
-        }
-    }
-
 // every element with 0 in the owners field can only reach the null pointer and itself
 invariant nextNull()
     ghostOwners[NULL] == 0 &&
@@ -289,12 +277,11 @@ rule isOwnerDoesNotRevert {
     assert !lastReverted, "isOwner should not revert";
 }
 
-rule isOwnerNotSelfOrSentinel {
+rule isOwnerNotSentinel {
     address addr;
-    require addr == currentContract || addr == SENTINEL;
-    requireInvariant self_not_owner();
+    require addr == SENTINEL;
     bool result = isOwner(addr);
-    assert result == false, "currentContract or SENTINEL must not be owners";
+    assert result == false, "SENTINEL must not be owners";
 }
 
 rule isOwnerInList {

--- a/contracts/base/OwnerManager.sol
+++ b/contracts/base/OwnerManager.sol
@@ -39,10 +39,9 @@ abstract contract OwnerManager is SelfAuthorized, IOwnerManager {
         for (uint256 i = 0; i < ownersLength; ++i) {
             // Owner address cannot be null.
             address owner = _owners[i];
-            if (owner == address(0) || owner == SENTINEL_OWNERS || owner == address(this) || currentOwner == owner)
-                revertWithError("GS203");
+            if (owner == address(0) || owner == SENTINEL_OWNERS) revertWithError("GS203");
             // No duplicate owners allowed.
-            if (owners[owner] != address(0)) revertWithError("GS204");
+            if (owner == currentOwner || owners[owner] != address(0)) revertWithError("GS204");
             owners[currentOwner] = owner;
             currentOwner = owner;
         }
@@ -56,7 +55,7 @@ abstract contract OwnerManager is SelfAuthorized, IOwnerManager {
      */
     function addOwnerWithThreshold(address owner, uint256 _threshold) public override authorized {
         // Owner address cannot be null, the sentinel or the Safe itself.
-        if (owner == address(0) || owner == SENTINEL_OWNERS || owner == address(this)) revertWithError("GS203");
+        if (owner == address(0) || owner == SENTINEL_OWNERS) revertWithError("GS203");
         // No duplicate owners allowed.
         if (owners[owner] != address(0)) revertWithError("GS204");
         owners[owner] = owners[SENTINEL_OWNERS];

--- a/test/core/Safe.OwnerManager.spec.ts
+++ b/test/core/Safe.OwnerManager.spec.ts
@@ -25,18 +25,6 @@ describe("OwnerManager", () => {
             await expect(safe.addOwnerWithThreshold(user2.address, 1)).to.be.revertedWith("GS031");
         });
 
-        it("can not set Safe itself", async () => {
-            const {
-                safe,
-                signers: [user1],
-            } = await setupTests();
-            const safeAddress = await safe.getAddress();
-
-            await expect(executeContractCallWithSigners(safe, safe, "addOwnerWithThreshold", [safeAddress, 1], [user1])).to.revertedWith(
-                "GS203",
-            );
-        });
-
         it("can not set sentinel", async () => {
             const {
                 safe,

--- a/test/core/Safe.Setup.spec.ts
+++ b/test/core/Safe.Setup.spec.ts
@@ -137,17 +137,6 @@ describe("Safe", () => {
             ).to.be.revertedWith("GS203");
         });
 
-        it("should revert if Safe itself is used as an owner", async () => {
-            const {
-                template,
-                signers: [, user2],
-            } = await setupTests();
-            const templateAddress = await template.getAddress();
-            await expect(
-                template.setup([user2.address, templateAddress], 2, AddressZero, "0x", AddressZero, AddressZero, 0, AddressZero),
-            ).to.be.revertedWith("GS203");
-        });
-
         it("should revert if sentinel is used as an owner", async () => {
             const {
                 template,
@@ -165,7 +154,7 @@ describe("Safe", () => {
             } = await setupTests();
             await expect(
                 template.setup([user2.address, user2.address], 2, AddressZero, "0x", AddressZero, AddressZero, 0, AddressZero),
-            ).to.be.revertedWith("GS203");
+            ).to.be.revertedWith("GS204");
         });
 
         it("should revert if threshold is too high", async () => {

--- a/test/core/Safe.Signatures.spec.ts
+++ b/test/core/Safe.Signatures.spec.ts
@@ -503,9 +503,9 @@ describe("Safe", () => {
 
             const selfSignature = {
                 signer: safeAddress,
-                data: buildSignatureBytes([await safeApproveHash(safe, safe, tx, true)]),
+                data: buildSignatureBytes([await safeApproveHash(await hre.ethers.getSigner(safeAddress), safe, tx, true)]),
                 dynamic: true,
-            };
+            } as const;
             const signatures = buildSignatureBytes([selfSignature]);
 
             await expect(safe["checkSignatures(address,bytes32,bytes)"](user1.address, txHash, signatures)).to.be.revertedWith("GS025");

--- a/test/core/Safe.Signatures.spec.ts
+++ b/test/core/Safe.Signatures.spec.ts
@@ -8,6 +8,7 @@ import { getSafeTemplate, getSafe } from "../utils/setup";
 import {
     safeSignTypedData,
     executeTx,
+    executeContractCallWithSigners,
     safeSignMessage,
     calculateSafeTransactionHash,
     safeApproveHash,
@@ -480,6 +481,34 @@ describe("Safe", () => {
             ]);
 
             await safe["checkSignatures(address,bytes32,bytes)"](user1.address, txHash, signatures);
+        });
+
+        it("should not allow trivial signatures when the Safe owns itself", async () => {
+            const {
+                signers: [user1],
+            } = await setupTests();
+            const compatFallbackHandler = await getCompatFallbackHandler();
+            const compatFallbackHandlerAddress = await compatFallbackHandler.getAddress();
+            const safe = await getSafe({
+                owners: [user1.address],
+                threshold: 1,
+                fallbackHandler: compatFallbackHandlerAddress,
+            });
+            const safeAddress = await safe.getAddress();
+
+            await executeContractCallWithSigners(safe, safe, "addOwnerWithThreshold", [safeAddress, 1], [user1]);
+
+            const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
+            const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
+
+            const selfSignature = {
+                signer: safeAddress,
+                data: buildSignatureBytes([await safeApproveHash(safe, safe, tx, true)]),
+                dynamic: true,
+            };
+            const signatures = buildSignatureBytes([selfSignature]);
+
+            await expect(safe["checkSignatures(address,bytes32,bytes)"](user1.address, txHash, signatures)).to.be.revertedWith("GS025");
         });
     });
 


### PR DESCRIPTION
This change was originally proposed by @akshay-ap 

This PR reverts an old change (See #229 and #259) and allows the Safe to once again own itself. This is a step towards 7702 support (#997), whereby we want the EOA that delegates to a Safe to be able to sign transactions for itself.

The restriction was originally put in place because `execTransaction` would call `isValidSignature` on itself (which used to be implemented on the Safe itself and not as part of the compatibility fallback handler), where the `msg.sender` would be the Safe itself, and allow for trivial "approved hash" signatures (through
[this](https://github.com/safe-global/safe-smart-account/blob/36db12a140331c522e773849ebc87d39f5abae1e/contracts/GnosisSafe.sol#L244-L245) mechanism).

This is no longer possible since v1.3.0, as the `isValidSignature` call would be handled by the fallback handler, meaning that the `msg.sender` that can trivially sign "approve hash" signatures is no longer the Safe itself but the configured fallback handler. Since #866 and starting in v1.5.0 the `CompatibilityFallbackHandler` is implemented to disallow "approve hash" signatures regardless of the caller, further eliminating the requirement for the restriction.

### Increasing Threshold Concerns

One concern with this change, and removing the restriction on having the Safe own itself, is that the Safe cannot sign for itself, so you can potentially block access to the account completely, by requiring the Safe "self-owner" to be included as part of the signing threshold. For example, if you have a n/n Safe (so `threshold == ownerCount`) and one of the owners is the Safe itself, then the Safe will not be able to ever produce a valid signature.