### PR TITLE
Fix: Standardize Revert Message Casing in ProxyFactory Tests

### DIFF
--- a/test/factory/ProxyFactory.spec.ts
+++ b/test/factory/ProxyFactory.spec.ts
@@ -23,7 +23,7 @@ describe("ProxyFactory", () => {
         }
 
         function revertingInitializer() public {
-            revert("initilalization reverted");
+            revert("initialization reverted");
         }
 
         function masterCopy() public pure returns (address) {
@@ -117,7 +117,7 @@ describe("ProxyFactory", () => {
             const singletonAddress = await singleton.getAddress();
             const initCode = singleton.interface.encodeFunctionData("revertingInitializer", []);
             await expect(factory.createProxyWithNonce(singletonAddress, initCode, saltNonce)).to.be.revertedWith(
-                "initilalization reverted",
+                "initialization reverted",
             );
         });
     });
@@ -197,7 +197,7 @@ describe("ProxyFactory", () => {
             const singletonAddress = await singleton.getAddress();
             const initCode = singleton.interface.encodeFunctionData("revertingInitializer", []);
             await expect(factory.createProxyWithNonceL2(singletonAddress, initCode, saltNonce)).to.be.revertedWith(
-                "initilalization reverted",
+                "initialization reverted",
             );
         });
     });


### PR DESCRIPTION


**Description:**  
This pull request updates the revert message in `ProxyFactory.spec.ts` to use consistent lowercase casing ("initialization reverted") across all relevant tests and the reverting initializer function. 