### PR TITLE
Add Warning for Self-Owned Safes

### DIFF
--- a/contracts/interfaces/IOwnerManager.sol
+++ b/contracts/interfaces/IOwnerManager.sol
@@ -28,6 +28,12 @@ interface IOwnerManager {
     /**
      * @notice Adds the owner `owner` to the Safe and updates the threshold to `_threshold`.
      * @dev This can only be done via a Safe transaction.
+     *      ⚠️⚠️⚠️ A Safe can set itself as an owner which is a valid setup for EIP-7702 delegations.
+     *      However, if address of the accounts is not an EOA and cannot sign for itself, you can
+     *      potentially block access to the account completely. For example, if you have a `n/n`
+     *      Safe (so `threshold == ownerCount`) and one of the owners is the Safe itself and not
+     *      an EIP-7702 delegated account, then it will not be possible to produce a valid
+     *      signature for the Safe. ⚠️⚠️⚠️
      * @param owner New owner address.
      * @param _threshold New threshold.
      */
@@ -48,6 +54,12 @@ interface IOwnerManager {
     /**
      * @notice Replaces the owner `oldOwner` in the Safe with `newOwner`.
      * @dev This can only be done via a Safe transaction.
+     *      ⚠️⚠️⚠️ A Safe can set itself as an owner which is a valid setup for EIP-7702 delegations.
+     *      However, if address of the accounts is not an EOA and cannot sign for itself, you can
+     *      potentially block access to the account completely. For example, if you have a `n/n`
+     *      Safe (so `threshold == ownerCount`) and one of the owners is the Safe itself and not
+     *      an EIP-7702 delegated account, then it will not be possible to produce a valid
+     *      signature for the Safe. ⚠️⚠️⚠️
      * @param prevOwner Owner that pointed to the `oldOwner` to be replaced in the linked list.
      *        If the owner to be replaced is the first (or only) element of the list,
      *        `prevOwner` MUST be set to the sentinel address `0x1` (referred to as

--- a/contracts/interfaces/ISafe.sol
+++ b/contracts/interfaces/ISafe.sol
@@ -55,6 +55,12 @@ interface ISafe is INativeCurrencyPaymentFallback, IModuleManager, IGuardManager
      * @notice Sets an initial storage of the Safe account.
      * @dev This method can only be called once.
      *      ⚠️⚠️⚠️ If a proxy was created without setting up, anyone can call setup and claim the proxy. ⚠️⚠️⚠️
+     *      ⚠️⚠️⚠️ A Safe can set itself as an owner which is a valid setup for EIP-7702 delegations.
+     *      However, if address of the accounts is not an EOA and cannot sign for itself, you can
+     *      potentially block access to the account completely. For example, if you have a `n/n`
+     *      Safe (so `threshold == ownerCount`) and one of the owners is the Safe itself and not
+     *      an EIP-7702 delegated account, then it will not be possible to produce a valid
+     *      signature for the Safe. ⚠️⚠️⚠️
      *      This method emits a {SafeSetup} event with the setup parameters instead of reading from storage,
      *      which may be inaccurate if the delegate call to `to` modifies the owners, threshold or fallback handler.
      * @param _owners Array of initial Safe owners.


### PR DESCRIPTION
Follow-up to comment by @remedcu, that we should warn against a Safe self-owning itself unless it is a EIP-7702 delegated account.