### PR TITLE
Creation Code Hash

### DIFF
--- a/contracts/proxies/SafeProxyFactory.sol
+++ b/contracts/proxies/SafeProxyFactory.sol
@@ -36,11 +36,12 @@ contract SafeProxyFactory {
     }
 
     /**
-     * @notice Retrieve the {SafeProxy} creation codehash.
+     * @notice Retrieve the {SafeProxy} creation codehash based on singleton.
+     * @param singleton Address of the singleton contract that the proxy will delegate calls to.
      * @dev The returned creation codehash can be used to compute a {SafeProxy} creation address.
      */
-    function proxyCreationCodehash() public pure returns (bytes32) {
-        return keccak256(type(SafeProxy).creationCode);
+    function proxyCreationCodehash(address singleton) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(type(SafeProxy).creationCode, uint256(uint160(singleton))));
     }
 
     /**

--- a/contracts/proxies/SafeProxyFactory.sol
+++ b/contracts/proxies/SafeProxyFactory.sol
@@ -36,6 +36,14 @@ contract SafeProxyFactory {
     }
 
     /**
+     * @notice Retrieve the {SafeProxy} creation codehash.
+     * @dev The returned creation codehash can be used to compute a {SafeProxy} creation address.
+     */
+    function proxyCreationCodehash() public pure returns (bytes32) {
+        return keccak256(type(SafeProxy).creationCode);
+    }
+
+    /**
      * @notice Internal method to create a new proxy contract using `CREATE2`. Optionally executes an initializer call to a new proxy.
      * @param _singleton Address of singleton contract. Must be deployed at the time of execution.
      * @param initializer Optional payload for a message call to be sent to a new proxy contract.

--- a/test/factory/ProxyFactory.spec.ts
+++ b/test/factory/ProxyFactory.spec.ts
@@ -48,8 +48,18 @@ describe("ProxyFactory", () => {
         };
     });
 
-    describe("proxyCreationCode", () => {
-        it("should be possible to predict the create2 address of a proxy", async () => {
+    describe("proxyCreationCode && proxyCreationCodeHash", () => {
+        it("hash of proxyCreationCode, singleton should be equal to the proxyCreationCodeHash", async () => {
+            const { factory, singleton } = await setupTests();
+            const creationCode = await factory.proxyCreationCode();
+            const creationCodeHash = await factory.proxyCreationCodehash(await singleton.getAddress());
+            const calculatedCreationCodeHash = ethers.keccak256(
+                ethers.solidityPacked(["bytes", "uint256"], [creationCode, await singleton.getAddress()]),
+            );
+            expect(calculatedCreationCodeHash).to.be.eq(creationCodeHash);
+        });
+
+        it("should be possible to predict the create2 address of a proxy with proxyCreationCode", async () => {
             const { factory, singleton } = await setupTests();
             const saltNonce = 42n;
             const singletonAddress = await singleton.getAddress();
@@ -67,6 +77,23 @@ describe("ProxyFactory", () => {
                 salt,
                 ethers.keccak256(deploymentCode),
             );
+
+            expect(proxyAddress).to.be.eq(calculatedProxyAddressWithEthers);
+        });
+
+        it("should be possible to predict the create2 address of a proxy with proxyCreationCodeHash", async () => {
+            const { factory, singleton } = await setupTests();
+            const saltNonce = 42n;
+            const singletonAddress = await singleton.getAddress();
+            const initCode = singleton.interface.encodeFunctionData("init", []);
+            const creationCodeHash = await factory.proxyCreationCodehash(await singleton.getAddress());
+            const salt = ethers.solidityPackedKeccak256(
+                ["bytes32", "uint256"],
+                [ethers.solidityPackedKeccak256(["bytes"], [initCode]), saltNonce],
+            );
+
+            const proxyAddress = await factory.createProxyWithNonce.staticCall(singletonAddress, initCode, saltNonce);
+            const calculatedProxyAddressWithEthers = ethers.getCreate2Address(await factory.getAddress(), salt, creationCodeHash);
 
             expect(proxyAddress).to.be.eq(calculatedProxyAddressWithEthers);
         });


### PR DESCRIPTION
# TLDR
- Adds the creation code hash in Safe Proxy Factory.

## LLM Description
This pull request introduces a new method in the `SafeProxyFactory` contract to enhance functionality by providing the ability to retrieve the creation code hash of a `SafeProxy`. This addition can be used to compute a `SafeProxy` creation address.

Enhancements to `SafeProxyFactory`:

* [`contracts/proxies/SafeProxyFactory.sol`](diffhunk://#diff-53aac98a01e16743466b00bdcb233208f95e1113cc90b95181187d9862b4ad6eR38-R45): Added the `proxyCreationCodehash` method, which returns the keccak256 hash of the `SafeProxy` creation code. This method is marked as `public` and `pure`, and it can be used to compute the creation address of a `SafeProxy`.

Fixes #994 