### PR TITLE
refactor: replace string concatenation with template literals

### DIFF
--- a/src/utils/execution.ts
+++ b/src/utils/execution.ts
@@ -91,11 +91,7 @@ export const safeApproveHash = async (
     const signerAddress = await signer.getAddress();
     return {
         signer: signerAddress,
-        data:
-            "0x000000000000000000000000" +
-            signerAddress.slice(2) +
-            "0000000000000000000000000000000000000000000000000000000000000000" +
-            "01",
+        data: `0x000000000000000000000000${signerAddress.slice(2)}0000000000000000000000000000000000000000000000000000000000000000${"01"}`,
     };
 };
 


### PR DESCRIPTION
Replaced multiple string concatenation operations with a single template literal in the safeApproveHash function for improved readability and performance. Template literals are more efficient than multiple string concatenations while maintaining the same functionality.