### PR TITLE
Revert "fix: optimize SafeMath.sub implementation for gas efficiency"

### DIFF
--- a/contracts/external/SafeMath.sol
+++ b/contracts/external/SafeMath.sol
@@ -34,7 +34,9 @@ library SafeMath {
      */
     function sub(uint256 a, uint256 b) internal pure returns (uint256) {
         require(b <= a);
-        return a - b;
+        uint256 c = a - b;
+
+        return c;
     }
 
     /**


### PR DESCRIPTION
Reverts safe-global/safe-smart-account#1026

We are reverting because the affirmation for having read and accepted the CLA is missing from the pull request:

> I have read the CLA Document and I hereby sign the CLA

The CLA bot seems to have recorded a comment that is no longer part of the pull request.

@strmfos if you want to include the change again, please recreate the PR and include the following in the PR description:

```markdown
## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
```