### PR TITLE
Remove `strfmos` CLA Entry

### DIFF
--- a/signatures/version1/cla.json
+++ b/signatures/version1/cla.json
@@ -495,14 +495,6 @@
       "created_at": "2025-07-12T14:41:10Z",
       "repoId": 102186072,
       "pullRequestNo": 1020
-    },
-    {
-      "name": "strmfos",
-      "id": 155266597,
-      "comment_id": 3127304684,
-      "created_at": "2025-07-28T13:41:29Z",
-      "repoId": 102186072,
-      "pullRequestNo": 1026
     }
   ]
 }


### PR DESCRIPTION
Remove `strfmos` CLA entry - the CLA bot added it but there is no record of them accepting the CLA in the PR.