### PR TITLE
Update GitHub Actions in CI Workflows 

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -18,7 +18,7 @@ jobs:
                 rule: ["execute", "extensible", "fallback", "guards", "hash", "module", "nativeTokenRefund", "owner", "safe", "safeMigration", "safeToL2Setup", "setup", "signatures"]
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - name: Install python
               uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     lint-solidity:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - uses: actions/setup-node@v4
               with:
                   node-version: ${{ env.NODE_VERSION }}
@@ -19,7 +19,7 @@ jobs:
     lint-typescript:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - uses: actions/setup-node@v4
               with:
                   node-version: ${{ env.NODE_VERSION }}
@@ -32,7 +32,7 @@ jobs:
     tests:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - uses: actions/setup-node@v4
               with:
                   node-version: ${{ env.NODE_VERSION }}
@@ -50,7 +50,7 @@ jobs:
         env:
             SAFE_CONTRACT_UNDER_TEST: ${{ matrix.contract-name }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - uses: actions/setup-node@v4
               with:
                   node-version: ${{ env.NODE_VERSION }}
@@ -89,7 +89,7 @@ jobs:
             SOLIDITY_VERSION: ${{ matrix.solidity }}
             SOLIDITY_SETTINGS: ${{ matrix.settings }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - uses: actions/setup-node@v4
               with:
                   node-version: ${{ env.NODE_VERSION }}


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0