### PR TITLE
fix: typos and grammar in contracts and docs

### DIFF
--- a/contracts/base/FallbackManager.sol
+++ b/contracts/base/FallbackManager.sol
@@ -29,7 +29,7 @@ abstract contract FallbackManager is SelfAuthorized, IFallbackManager {
         // the call would end in a fallback handler. Since it appends the `msg.sender` address to the calldata, the attacker could craft an address
         // where the first 3 bytes of the previous calldata followed by the first byte of the attacker's address make up a valid function signature.
         // The subsequent call would result in unsanctioned access to Safe's internal protected methods. This happens as Solidity matches the first
-        // 4 bytes of the calldata to a function signature, regardless if more data follow these 4 bytes.
+        // 4 bytes of the calldata to a function signature, regardless if more data follows these 4 bytes.
         if (handler == address(this)) revertWithError("GS400");
 
         /* solhint-disable no-inline-assembly */

--- a/contracts/base/GuardManager.sol
+++ b/contracts/base/GuardManager.sol
@@ -67,7 +67,7 @@ abstract contract BaseTransactionGuard is ITransactionGuard {
 
 /**
  * @title Guard Manager
- * @notice A contract managing transaction guards which perform pre and post-checks on Safe transactions.
+ * @notice A contract managing transaction guards which perform pre- and post-checks on Safe transactions.
  * @author Richard Meissner - @rmeissner
  */
 abstract contract GuardManager is SelfAuthorized, IGuardManager {

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -164,7 +164,7 @@ contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidat
             // try to copy past the `returndatasize` bounds, so we don't need an
             // additional check here. However, do note that this will consume
             // all remaining gas. This is fine (since we don't aim to support
-            // other callers that aren't Safe with the compatibility fallback
+            // other callers that aren't Safes with the compatibility fallback
             // handler).
             let responseEncodedSize := add(mload(0x20), 0x20)
             response := mload(0x40)

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -136,7 +136,7 @@ contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidat
                 0,
                 ptr,
                 calldatasize(),
-                // The `simulateAndRevert` call should always reverts, and
+                // The `simulateAndRevert` call should always revert, and
                 // instead encodes whether or not it was successful in the
                 // return data. The first 32-byte word of the return data
                 // contains the `success` value, and the second 32-byte word
@@ -164,7 +164,7 @@ contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidat
             // try to copy past the `returndatasize` bounds, so we don't need an
             // additional check here. However, do note that this will consume
             // all remaining gas. This is fine (since we don't aim to support
-            // other callers that aren't Safes with the compatibility fallback
+            // other callers that aren't Safe with the compatibility fallback
             // handler).
             let responseEncodedSize := add(mload(0x20), 0x20)
             response := mload(0x40)

--- a/contracts/handler/HandlerContext.sol
+++ b/contracts/handler/HandlerContext.sol
@@ -26,7 +26,7 @@ abstract contract HandlerContext {
     }
 
     /**
-     * @dev Implementation of the {onlySafeFallback} modifier checks that the current call is a Safe
+     * @dev Implementation of the {onlySafeFallback} modifier that checks whether the current call is a fallback from a Safe
      *      fallback call, and the contract is not called directly. Note that this is only a **best
      *      effort** check and may generate false positives under certain conditions.
      */

--- a/contracts/handler/HandlerContext.sol
+++ b/contracts/handler/HandlerContext.sol
@@ -26,7 +26,7 @@ abstract contract HandlerContext {
     }
 
     /**
-     * @dev Implementation of the {onlySafeFallback} modifier check that the current call is a Safe
+     * @dev Implementation of the {onlySafeFallback} modifier checks that the current call is a Safe
      *      fallback call, and the contract is not called directly. Note that this is only a **best
      *      effort** check and may generate false positives under certain conditions.
      */

--- a/docs/safe_tx_gas.md
+++ b/docs/safe_tx_gas.md
@@ -28,9 +28,9 @@ This also results in the `nonce` of this transaction being used, so it is not po
 
 If `gasPrice` is set to `0` then the Safe Smart Account will **not** issue a refund after the Safe transaction execution.
 
-Therefore it is not necessary to be as strict on the gas being passed along with the execution of the Safe transaction. As no refund is triggered the Safe will not pay for the execution costs, based on this the Safe Smart Account will send along all available case when no refund is used.
+Therefore it is not necessary to be as strict on the gas being passed along with the execution of the Safe transaction. As no refund is triggered the Safe will not pay for the execution costs, based on this the Safe Smart Account will send along all available cases when no refund is used.
 
-Before the execution the Safe Smart Account always check if enough gas is available to satisfy the `safeTxGas`. This can be seen in [`Safe.sol`](https://github.com/safe-global/safe-smart-account/blob/c85741a6cda020cce3bc523c169909318717736f/contracts/Safe.sol#L168-L169):
+Before the execution the Safe Smart Account always checks if enough gas is available to satisfy the `safeTxGas`. This can be seen in [`Safe.sol`](https://github.com/safe-global/safe-smart-account/blob/c85741a6cda020cce3bc523c169909318717736f/contracts/Safe.sol#L168-L169):
 
 ```js
 require(gasleft() >= ((safeTxGas * 64) / 63).max(safeTxGas + 2500) + 500, "GS010");

--- a/docs/safe_tx_gas.md
+++ b/docs/safe_tx_gas.md
@@ -28,7 +28,7 @@ This also results in the `nonce` of this transaction being used, so it is not po
 
 If `gasPrice` is set to `0` then the Safe Smart Account will **not** issue a refund after the Safe transaction execution.
 
-Therefore it is not necessary to be as strict on the gas being passed along with the execution of the Safe transaction. As no refund is triggered the Safe will not pay for the execution costs, based on this the Safe Smart Account will send along all available cases when no refund is used.
+Therefore it is not necessary to be as strict on the gas being passed along with the execution of the Safe transaction. As no refund is triggered the Safe will not pay for the execution costs, the Safe Smart Account will send along all available gas when no refund is used.
 
 Before execution, the Safe Smart Account always checks if enough gas is available to satisfy the `safeTxGas`. This can be seen in [`Safe.sol`](https://github.com/safe-global/safe-smart-account/blob/c85741a6cda020cce3bc523c169909318717736f/contracts/Safe.sol#L168-L169):
 

--- a/docs/safe_tx_gas.md
+++ b/docs/safe_tx_gas.md
@@ -30,7 +30,7 @@ If `gasPrice` is set to `0` then the Safe Smart Account will **not** issue a ref
 
 Therefore it is not necessary to be as strict on the gas being passed along with the execution of the Safe transaction. As no refund is triggered the Safe will not pay for the execution costs, based on this the Safe Smart Account will send along all available cases when no refund is used.
 
-Before the execution the Safe Smart Account always checks if enough gas is available to satisfy the `safeTxGas`. This can be seen in [`Safe.sol`](https://github.com/safe-global/safe-smart-account/blob/c85741a6cda020cce3bc523c169909318717736f/contracts/Safe.sol#L168-L169):
+Before execution, the Safe Smart Account always checks if enough gas is available to satisfy the `safeTxGas`. This can be seen in [`Safe.sol`](https://github.com/safe-global/safe-smart-account/blob/c85741a6cda020cce3bc523c169909318717736f/contracts/Safe.sol#L168-L169):
 
 ```js
 require(gasleft() >= ((safeTxGas * 64) / 63).max(safeTxGas + 2500) + 500, "GS010");


### PR DESCRIPTION
- FallbackManager.sol – corrected "follows" instead of "follow".

- GuardManager.sol – clarified phrasing to "pre- and post-checks".

- CompatibilityFallbackHandler.sol – fixed grammar in comments ("revert" and "Safe").

- HandlerContext.sol – corrected modifier description to "checks".

- safe_tx_gas.md – fixed typos ("cases" instead of "case", "checks" instead of "check").