### PR TITLE
Use proper solidity version range

### DIFF
--- a/contracts/libraries/SafeStorage.sol
+++ b/contracts/libraries/SafeStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity >=0.7.0 <0.9.0;
+pragma solidity >=0.7.4 <0.9.0;
 
 /**
  * @title Safe Storage


### PR DESCRIPTION
`SafeStorage.sol` uses constants at the file level, which were introduced in [Solidity 0.7.4](https://soliditylang.org/blog/2020/10/19/solidity-0.7.4-release-announcement/).

I found this while using real repositories to battle-test the [`compatible-pragma`](https://github.com/fvictorio/slippy/blob/main/docs/rules/compatible-pragma.md) rule of [Slippy](https://github.com/fvictorio/slippy), a new Solidity linter I'm working on. So this PR also serves as a suggestion to migrate from Solhint to Slippy :slightly_smiling_face: (Happy to send a PR doing that if you are interested!)