### PR TITLE
Update GitHub Actions setup-node to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v5
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   cache: "npm"
@@ -33,7 +33,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v5
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   cache: "npm"
@@ -51,7 +51,7 @@ jobs:
             SAFE_CONTRACT_UNDER_TEST: ${{ matrix.contract-name }}
         steps:
             - uses: actions/checkout@v5
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   cache: "npm"
@@ -90,7 +90,7 @@ jobs:
             SOLIDITY_SETTINGS: ${{ matrix.settings }}
         steps:
             - uses: actions/checkout@v5
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   cache: "npm"


### PR DESCRIPTION
Bumped actions/setup-node from v4 → v5
Using the latest version ensures continued support, bug fixes, and compatibility improvements.

Official release: https://github.com/actions/setup-node/releases/tag/v5.0.0

