### PR TITLE
Use nullish coalescing in buildSafeTransaction to preserve intentional falsy values

### DIFF
--- a/src/utils/execution.ts
+++ b/src/utils/execution.ts
@@ -268,16 +268,17 @@ export const buildSafeTransaction = (template: {
     refundReceiver?: string;
     nonce: BigNumberish;
 }): SafeTransaction => {
+    // Use nullish coalescing so intentional falsy values (e.g., 0) are preserved
     return {
         to: template.to,
-        value: template.value || 0,
-        data: template.data || "0x",
-        operation: template.operation || 0,
-        safeTxGas: template.safeTxGas || 0,
-        baseGas: template.baseGas || 0,
-        gasPrice: template.gasPrice || 0,
-        gasToken: template.gasToken || AddressZero,
-        refundReceiver: template.refundReceiver || AddressZero,
+        value: template.value ?? 0,
+        data: template.data ?? "0x",
+        operation: template.operation ?? 0,
+        safeTxGas: template.safeTxGas ?? 0,
+        baseGas: template.baseGas ?? 0,
+        gasPrice: template.gasPrice ?? 0,
+        gasToken: template.gasToken ?? AddressZero,
+        refundReceiver: template.refundReceiver ?? AddressZero,
         nonce: template.nonce,
     };
 };


### PR DESCRIPTION


Description
- Summary: Replace logical OR fallbacks with nullish coalescing in buildSafeTransaction to avoid overwriting intentional falsy values (e.g., 0).
- Why: || treats 0/"" as falsy and replaces them with defaults, which can mask valid inputs and cause subtle bugs.
- Change:
  - value/data/operation/safeTxGas/baseGas/gasPrice/gasToken/refundReceiver now use ?? with safe defaults.



