### PR TITLE
Upgrade GitHub Action to setup-python@v6

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -21,7 +21,7 @@ jobs:
             - uses: actions/checkout@v5
 
             - name: Install python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with: { python-version: 3.11 }
 
             - name: Install certora cli


### PR DESCRIPTION
Version v6 improves setup speed, adds better caching, and ensures full compatibility with the latest Python versions.
Release notes: https://github.com/actions/setup-python/releases/tag/v6.0.0