### PR TITLE
Update CLA Assistant GitHub Action to v2.6.1

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Beta Release
-        uses: cla-assistant/github-action@v2.3.0
+        uses: cla-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret


### PR DESCRIPTION
Version v2.6.1 provides improved stability, updated dependencies, and enhanced security features for CLA validation workflows.
Release notes: https://github.com/contributor-assistant/github-action/releases/tag/v2.6.1

Change:
uses: cla-assistant/github-action@v2.3.0 → uses: cla-assistant/github-action@v2.6.1