### PR TITLE
Update GitHub Action to setup-node@v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v5
-            - uses: actions/setup-node@v5
+            - uses: actions/setup-node@v6
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   cache: "npm"
@@ -33,7 +33,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v5
-            - uses: actions/setup-node@v5
+            - uses: actions/setup-node@v6
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   cache: "npm"
@@ -51,7 +51,7 @@ jobs:
             SAFE_CONTRACT_UNDER_TEST: ${{ matrix.contract-name }}
         steps:
             - uses: actions/checkout@v5
-            - uses: actions/setup-node@v5
+            - uses: actions/setup-node@v6
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   cache: "npm"


### PR DESCRIPTION
uses: actions/setup-node@v5 -> uses: actions/setup-node@v6

Release notes: actions/setup-node@v6.0.0: https://github.com/actions/setup-node/releases/tag/v6.0.0