### PR TITLE
Fix grammar in EIP7951.sol NatSpec comment

### DIFF
--- a/contracts/common/EIP7951.sol
+++ b/contracts/common/EIP7951.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.7.0 <0.9.0;
 
 /**
  * @title EIP-7951
- * @notice Base contract with adds support for calling the `p256verify` precompile.
+ * @notice Base contract that adds support for calling the `p256verify` precompile.
  * @dev This was split into its own function to enable CVL summaries for better formal verification support. Note that
  *      this contract also works with RIP-7212 which has the exact same interface.
  * @author Nicholas Rodrigues Lordello - @nlordell


### PR DESCRIPTION
## Summary
- Fixed grammatical error in EIP7951.sol NatSpec documentation
- Changed "Base contract with adds support" to "Base contract that adds support"

## Test plan
- [x] Comment-only change - no functional code affected