### PR TITLE
Revert "Fix typo: NatSepc -> NatSpec in guidelines"

### DIFF
--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -36,6 +36,6 @@ Note: Make sure to use a unique identifier else unexpected behaviour will occur.
 
 Use only `//` for comments and do not use block comments `/* ... */`. The exception to this rule is to use block comments for Solhint enable/disable directives: `/* solhint-{enable,disable} ... */`. Comments should be sentences: they should start with a capital letter and end with a dot.
 
-### NatSpec
+### NatSepc
 
 Use `/** */` for NatSpec comments and not `///`. Additionally, we use a non-standard notation for referencing symbols in a NatSpec documentation: `{someSymbol}` is a reference to the symbol (function, storage, constant, etc.) `someSymbol`.


### PR DESCRIPTION
Reverts safe-fndn/safe-smart-account#1075

While the above PR is a welcome addition, I unfortunately merged it without realizing that the contributor did not agree to the CLA. This PR reverts the change as they did not respond to whether or not they agree to the CLA.