### PR TITLE
fix: ExtensibleFallbackHandler IERC165Handler imports

### DIFF
--- a/contracts/handler/ExtensibleFallbackHandler.sol
+++ b/contracts/handler/ExtensibleFallbackHandler.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import {ERC165Handler} from "./extensible/ERC165Handler.sol";
+import {IERC165Handler, ERC165Handler} from "./extensible/ERC165Handler.sol";
 import {IFallbackHandler, FallbackHandler} from "./extensible/FallbackHandler.sol";
 import {ERC1271, ISignatureVerifierMuxer, SignatureVerifierMuxer} from "./extensible/SignatureVerifierMuxer.sol";
 import {ERC721TokenReceiver, ERC1155TokenReceiver, TokenCallbacks} from "./extensible/TokenCallbacks.sol";
@@ -23,7 +23,7 @@ contract ExtensibleFallbackHandler is FallbackHandler, SignatureVerifierMuxer, T
             interfaceId == type(ERC1155TokenReceiver).interfaceId ||
             interfaceId == type(ERC1271).interfaceId ||
             interfaceId == type(ISignatureVerifierMuxer).interfaceId ||
-            interfaceId == type(ERC165Handler).interfaceId ||
+            interfaceId == type(IERC165Handler).interfaceId ||
             interfaceId == type(IFallbackHandler).interfaceId;
     }
 }


### PR DESCRIPTION
`ERC165Handler` is the abstract contract
`IERC165Handler` is the interface

See:
https://github.com/safe-fndn/safe-smart-account/blob/a2e19c6aa42a45ceec68057f3fa387f169c5b321/contracts/handler/extensible/ERC165Handler.sol#L7
https://github.com/safe-fndn/safe-smart-account/blob/a2e19c6aa42a45ceec68057f3fa387f169c5b321/contracts/handler/extensible/ERC165Handler.sol#L17

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
