### PR TITLE
docs: align smart contract comment style

### DIFF
--- a/contracts/base/Executor.sol
+++ b/contracts/base/Executor.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
+
 import {Enum} from "../interfaces/Enum.sol";
 
 /**

--- a/contracts/base/FallbackManager.sol
+++ b/contracts/base/FallbackManager.sol
@@ -24,10 +24,13 @@ abstract contract FallbackManager is SelfAuthorized, IFallbackManager {
         //             withdrawalAddress.call.value(address(this).balance)("");
         //         }
         //
-        // If the fallback method is triggered, the fallback handler appends the `msg.sender` address to the calldata and calls the fallback handler.
-        // A potential attacker could call a Safe with the 3 bytes signature of a `withdraw` function. Since 3 bytes do not create a valid signature,
-        // the call would end in a fallback handler. Since it appends the `msg.sender` address to the calldata, the attacker could craft an address
-        // where the first 3 bytes of the previous calldata followed by the first byte of the attacker's address make up a valid function signature.
+        // If the fallback method is triggered, the fallback handler appends the `msg.sender` address to the calldata
+        // and calls the fallback handler.
+        // A potential attacker could call a Safe with the 3 bytes signature of a `withdraw` function.
+        // Since 3 bytes do not create a valid signature, the call would end in a fallback handler.
+        // Since it appends the `msg.sender` address to the calldata, the attacker could craft an address where the
+        // first 3 bytes of the previous calldata followed by the first byte of the attacker's address make up a valid
+        // function signature.
         // The subsequent call would result in unsanctioned access to Safe's internal protected methods. This happens as Solidity matches the first
         // 4 bytes of the calldata to a function signature, regardless if more data follows these 4 bytes.
         if (handler == address(this)) revertWithError("GS400");

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 /* solhint-disable one-contract-per-file */
 pragma solidity >=0.7.0 <0.9.0;
+
 import {SelfAuthorized} from "./../common/SelfAuthorized.sol";
 import {IERC165} from "./../interfaces/IERC165.sol";
 import {IModuleManager} from "./../interfaces/IModuleManager.sol";

--- a/contracts/interfaces/ISafe.sol
+++ b/contracts/interfaces/ISafe.sol
@@ -84,8 +84,9 @@ interface ISafe is INativeCurrencyPaymentFallback, IModuleManager, IGuardManager
         address payable paymentReceiver
     ) external;
 
-    /** @notice Executes a transaction with `operation` to the `to` address with a native token `value` with a `data` payload.
-     *          Pays `gasPrice * gasLimit` in `gasToken` token to the `refundReceiver`.
+    /**
+     * @notice Executes a transaction with `operation` to the `to` address with a native token `value` with a `data` payload.
+     *         Pays `gasPrice * gasLimit` in `gasToken` token to the `refundReceiver`.
      * @dev The fees are always transferred, even if the user transaction fails.
      *      This method doesn't perform any sanity check of the transaction, such as:
      *      - if the contract at `to` address has code or not


### PR DESCRIPTION
﻿## Summary
- align `ISafe.execTransaction` NatSpec block formatting with the surrounding interface comments
- wrap the long `FallbackManager` fallback-handler attack-vector comments for readability
- add the common blank line between `pragma` and imports in `Executor` and `ModuleManager`

Refs #954

## Validation
- `npm ci` (also ran the repo prepublish build)
- `npx prettier --check contracts/base/Executor.sol contracts/base/ModuleManager.sol contracts/base/FallbackManager.sol contracts/interfaces/ISafe.sol`
- `npx solhint contracts/base/Executor.sol contracts/base/ModuleManager.sol contracts/base/FallbackManager.sol contracts/interfaces/ISafe.sol`
- `npm run build`
- `git diff --check`

Note: `npm run lint:sol` does not expand the single-quoted glob on Windows and exits with `No files to lint`, so solhint was run directly on the touched Solidity files.
