### PR TITLE
Avoid mutating signature arrays in buildSignatureBytes

### DIFF
--- a/test/core/Safe.Signatures.spec.ts
+++ b/test/core/Safe.Signatures.spec.ts
@@ -101,6 +101,26 @@ describe("Safe", () => {
         });
     });
 
+    describe("buildSignatureBytes", () => {
+        it("should not mutate signature order", () => {
+            const signatures = [
+                {
+                    signer: "0x0000000000000000000000000000000000000002",
+                    data: `0x${"22".repeat(65)}`,
+                },
+                {
+                    signer: "0x0000000000000000000000000000000000000001",
+                    data: `0x${"11".repeat(65)}`,
+                },
+            ];
+            const signerOrder = signatures.map(({ signer }) => signer);
+
+            buildSignatureBytes(signatures);
+
+            expect(signatures.map(({ signer }) => signer)).to.deep.eq(signerOrder);
+        });
+    });
+
     describe("execTransaction", () => {
         it("should fail if signature points into static part", async () => {
             const {


### PR DESCRIPTION
---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).


This PR updates `buildSignatureBytes` to sort a copy of the provided signatures instead of sorting the input array in place.

`buildSignatureBytes` needs signatures ordered by signer address for Safe signature encoding, but mutating the caller-provided array can be surprising when the same signature list is reused later in a test or helper flow.


- Sort a copied signatures array before encoding.
- Keep the encoded signature bytes behavior unchanged.
- Add a regression test that verifies the original signature order is preserved after calling `buildSignatureBytes`.
